### PR TITLE
 Assignment of clients to Refill-Groups or Pharmacies depending on their DSD Model

### DIFF
--- a/api/src/main/resources/liquibase.xml
+++ b/api/src/main/resources/liquibase.xml
@@ -591,6 +591,15 @@ VALUES
 			DELETE FROM scheduler_task_config WHERE uuid = '415b8d70-6b45-41d8-a0ba-41b1a6b8aa1f';
 		</sql>
 	</changeSet>
+	<changeSet id="ugandaemr-20210823-0915" author="dbaluku">
+		<comment>Insert Cohort type for CDDP Group </comment>
+		<sql>
+			REPLACE INTO cohort_type(name,date_created,creator,uuid)VALUES
+			('CRPDDP Cohort Type','2021-08-23',1,'e50fa0af-df36-4a26-853f-feb05244e5ca'),
+			('CLDDP Cohort Type','2021-08-23',1,'aa536e57-a3c3-453c-9413-cf70b5d2ad5d'),
+			('CCLAD Cohort Type','2021-08-23',1,'5b7136fa-d207-4229-94a8-da6661ae00bf');
+		</sql>
+	</changeSet>
 </databaseChangeLog>
 
 

--- a/api/src/main/resources/metadata/Custom_Concepts.xml
+++ b/api/src/main/resources/metadata/Custom_Concepts.xml
@@ -823,6 +823,15 @@
     <concept concept_id="165139" retired="false" datatype_id="4" class_id="18" is_set="false" creator="1" date_created="2018-09-28 11:58:02"   uuid="73313f20-c321-11e8-a355-529269fb1459"/>
     <concept concept_id="165138" retired="false" datatype_id="4" class_id="18" is_set="false" creator="1" date_created="2018-09-28 11:56:02"   uuid="733144c0-c321-11e8-a355-529269fb1459"/>
 
+    <concept  concept_id="166476"  retired="0" datatype_id="3"  class_id="7"  is_set="0"  creator="1"  date_created="2021-08-22 15:15:24"  version=""  changed_by="1"  date_changed="2021-08-22 15:15:24" uuid="532b0735-1443-4ef5-95ed-bab0bb7b78d4"/>
+    <concept  concept_id="166475"  retired="0" datatype_id="3"  class_id="5"  is_set="0"  creator="1"  date_created="2021-08-22 15:13:37"  version=""  changed_by="1"  date_changed="2021-08-22 15:13:37" uuid="88d93029-3358-42cb-98f9-ea9b13286653"/>
+    <concept  concept_id="166474"  retired="0" datatype_id="2"  class_id="7"  is_set="0"  creator="1"  date_created="2021-08-22 15:10:11"  version=""  changed_by="1"  date_changed="2021-08-22 15:10:11" uuid="d951c873-e83b-4e09-a714-3ec94bac1735"/>
+    <concept  concept_id="166473"  retired="0" datatype_id="4"  class_id="5"  is_set="0"  creator="1"  date_created="2021-08-22 15:08:54"  version=""  changed_by="1"  date_changed="2021-08-22 15:08:54" uuid="2a989101-69a0-4119-8e64-d0731dbfc5df"/>
+    <concept  concept_id="166472"  retired="0" datatype_id="4"  class_id="5"  is_set="0"  creator="1"  date_created="2021-08-22 15:01:14"  version=""  changed_by="1"  date_changed="2021-08-22 15:01:14" uuid="6538ad8f-097d-40c7-be5d-c5ef62426b54"/>
+    <concept  concept_id="166471"  retired="0" datatype_id="4"  class_id="5"  is_set="0"  creator="1"  date_created="2021-08-22 14:47:55"  version=""  changed_by="1"  date_changed="2021-08-22 15:03:33" uuid="a22f466d-28b4-435b-9255-378a3feb0ea3"/>
+
+
+
     <!--TB-->
     <concept concept_id="1574" retired="false" datatype_id="4" class_id="11" is_set="false" creator="1" date_created="2008-04-07 15:37:44.0" version="" uuid="1574AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"/>
     <concept concept_id="1577" retired="false" datatype_id="4" class_id="11" is_set="false" creator="1" date_created="2008-04-07 15:39:54.0" version="" uuid="1577AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"/>
@@ -2168,6 +2177,7 @@
     <concept_description  concept_description_id="18342"  concept_id="165140"  description="DSDM for stable or unstable clients who need peer support"  locale="en"  creator="1"  date_created="2018-09-28 12:01:04" uuid="73314cc2-c321-11e8-a355-529269fb1459"/>
     <concept_description  concept_description_id="18341"  concept_id="165139"  description="DSDM Model for patients who only pick drugs at the health centre."  locale="en"  creator="1"  date_created="2018-09-28 11:58:02" uuid="73314f2e-c321-11e8-a355-529269fb1459"/>
     <concept_description  concept_description_id="18340"  concept_id="165138"  description="This is a DSDM model for patients that need extra management at the health centre"  locale="en"  creator="1"  date_created="2018-09-28 11:56:02" uuid="73315186-c321-11e8-a355-529269fb1459"/>
+
 
     <!--TB-->
     <concept_description concept_description_id="1435" concept_id="1574" description="Physician, doctor or clinical officer" locale="en" creator="1" date_created="2008-04-07 15:37:44.0" uuid="1435FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"/>
@@ -3771,6 +3781,17 @@
     <concept_name concept_name_id="160170"  concept_id="165139"  name="FTR"  locale="en"  locale_preferred="0"  creator="1"  date_created="2018-09-28 11:58:02"  concept_name_type="SHORT"  voided="0"  uuid="733172c4-c321-11e8-a355-529269fb1459"/>
     <concept_name concept_name_id="160167"  concept_id="165138"  name="FBIM"  locale="en"  locale_preferred="0"  creator="1"  date_created="2018-09-28 11:56:02"  concept_name_type="SHORT"  voided="0"  uuid="733175bc-c321-11e8-a355-529269fb1459"/>
     <concept_name concept_name_id="160168"  concept_id="165138"  name="Facility Based Individual Management"  locale="en"  locale_preferred="1"  creator="1"  date_created="2018-09-28 11:56:02"  concept_name_type="FULLY_SPECIFIED"  voided="0"  uuid="73317832-c321-11e8-a355-529269fb1459"/>
+    <concept_name  concept_name_id="162728"  concept_id="166471"  name="CLDDP"  locale="en"  locale_preferred="0"  creator="1"  date_created="2021-08-22 14:47:55"  concept_name_type="SHORT"  voided="0" uuid="c3493d58-9848-48a8-a77b-e3e45a486a0f"/>
+    <concept_name  concept_name_id="162729"  concept_id="166471"  name="Community Led Drug Distribution Point"  locale="en"  locale_preferred="1"  creator="1"  date_created="2021-08-22 14:47:55"  concept_name_type="FULLY_SPECIFIED"  voided="0" uuid="356cd0f9-d6b4-4f28-86c9-e2a9fbb0c1d5"/>
+    <concept_name  concept_name_id="162731"  concept_id="166472"  name="General CDDP"  locale="en"  locale_preferred="1"  creator="1"  date_created="2021-08-22 15:01:14"  concept_name_type="FULLY_SPECIFIED"  voided="0" uuid="a0b04738-41d1-4e14-aef6-531b0a4bc988"/>
+    <concept_name  concept_name_id="162732"  concept_id="166473"  name="CRPDDP"  locale="en"  locale_preferred="0"  creator="1"  date_created="2021-08-22 15:08:54"  concept_name_type="SHORT"  voided="0" uuid="5c0ff218-cb66-4e27-b507-e3aeb57a62c4"/>
+    <concept_name  concept_name_id="162733"  concept_id="166473"  name="Community Retail Pharmacy Drug Distribution Point"  locale="en"  locale_preferred="1"  creator="1"  date_created="2021-08-22 15:08:54"  concept_name_type="FULLY_SPECIFIED"  voided="0" uuid="b04971a9-04d6-42c2-b3f5-4097e21bca20"/>
+    <concept_name  concept_name_id="162734"  concept_id="166474"  name="Drug Pick Up Model"  locale="en"  locale_preferred="1"  creator="1"  date_created="2021-08-22 15:10:11"  concept_name_type="FULLY_SPECIFIED"  voided="0" uuid="48a545ca-e4bc-4c79-b0be-2bb33c194471"/>
+    <concept_name  concept_name_id="162735"  concept_id="166475"  name="CLDDP Location Name"  locale="en"  locale_preferred="1"  creator="1"  date_created="2021-08-22 15:13:37"  concept_name_type="FULLY_SPECIFIED"  voided="0" uuid="6976eb70-cc9e-47e8-9a5a-f30bd2ee6e17"/>
+    <concept_name  concept_name_id="162736"  concept_id="166476"  name="Pharmacy Code"  locale="en"  locale_preferred="1"  creator="1"  date_created="2021-08-22 15:15:24"  concept_name_type="FULLY_SPECIFIED"  voided="0" uuid="e70955c7-bc65-4eee-a7c7-1151cb9a1533"/>
+
+
+
 
     <!--TB-->
     <concept_name concept_id="71060" name="AMIKACIN" locale="en" creator="1" date_created="2006-12-17 00:00:00.0" concept_name_id="153738" voided="false" uuid="3738BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB" concept_name_type="FULLY_SPECIFIED" locale_preferred="true"/>
@@ -6946,7 +6967,9 @@
     <concept_answer  concept_answer_id="7087"  concept_id="165143"  answer_concept="165140" creator="1"  date_created="2018-10-15 13:02:40"  sort_weight="2"  uuid="7e9c8a31-3aee-4cd1-b3b8-32d18df2292a"/>
     <concept_answer  concept_answer_id="7090"  concept_id="165143"  answer_concept="165142" creator="1"  date_created="2018-10-15 13:02:40"  sort_weight="5"  uuid="cf6cea6f-c3e7-49f6-a447-15613f36504e"/>
     <concept_answer  concept_answer_id="7086"  concept_id="165143"  answer_concept="165138" creator="1"  date_created="2018-10-15 13:02:40"  sort_weight="1"  uuid="2faf6c05-3a99-41ef-be84-9fca5412b36c"/>
-
+    <concept_answer  concept_answer_id="7367859"  concept_id="166474"  answer_concept="166473" creator="1"  date_created="2021-08-22 15:10:11"  sort_weight="3"  uuid="1a4463e6-7419-473d-96ba-517b5960e862"/>
+    <concept_answer  concept_answer_id="7367860"  concept_id="166474"  answer_concept="166472" creator="1"  date_created="2021-08-22 15:10:11"  sort_weight="1"  uuid="95c89c42-89b3-45cd-b8ff-57ba6c9fa7ab"/>
+    <concept_answer  concept_answer_id="7367861"  concept_id="166474"  answer_concept="166471" creator="1"  date_created="2021-08-22 15:10:11"  sort_weight="2"  uuid="d123ed51-bedc-47e1-9c55-3cf0a2686c9e"/>
 
     <!--HTS-->
     <concept_answer  concept_answer_id="7135"  concept_id="165169"  answer_concept="162558"   creator="1"  date_created="2019-07-03 16:31:42"  sort_weight="11"  uuid="4bbf6750-6c86-4c6a-8633-fe5c696a8d86"/>

--- a/api/src/main/resources/metadata/Custom_Concepts.xml
+++ b/api/src/main/resources/metadata/Custom_Concepts.xml
@@ -823,12 +823,6 @@
     <concept concept_id="165139" retired="false" datatype_id="4" class_id="18" is_set="false" creator="1" date_created="2018-09-28 11:58:02"   uuid="73313f20-c321-11e8-a355-529269fb1459"/>
     <concept concept_id="165138" retired="false" datatype_id="4" class_id="18" is_set="false" creator="1" date_created="2018-09-28 11:56:02"   uuid="733144c0-c321-11e8-a355-529269fb1459"/>
 
-    <concept  concept_id="166476"  retired="0" datatype_id="3"  class_id="7"  is_set="0"  creator="1"  date_created="2021-08-22 15:15:24"  version=""  changed_by="1"  date_changed="2021-08-22 15:15:24" uuid="532b0735-1443-4ef5-95ed-bab0bb7b78d4"/>
-    <concept  concept_id="166475"  retired="0" datatype_id="3"  class_id="5"  is_set="0"  creator="1"  date_created="2021-08-22 15:13:37"  version=""  changed_by="1"  date_changed="2021-08-22 15:13:37" uuid="88d93029-3358-42cb-98f9-ea9b13286653"/>
-    <concept  concept_id="166474"  retired="0" datatype_id="2"  class_id="7"  is_set="0"  creator="1"  date_created="2021-08-22 15:10:11"  version=""  changed_by="1"  date_changed="2021-08-22 15:10:11" uuid="d951c873-e83b-4e09-a714-3ec94bac1735"/>
-    <concept  concept_id="166473"  retired="0" datatype_id="4"  class_id="5"  is_set="0"  creator="1"  date_created="2021-08-22 15:08:54"  version=""  changed_by="1"  date_changed="2021-08-22 15:08:54" uuid="2a989101-69a0-4119-8e64-d0731dbfc5df"/>
-    <concept  concept_id="166472"  retired="0" datatype_id="4"  class_id="5"  is_set="0"  creator="1"  date_created="2021-08-22 15:01:14"  version=""  changed_by="1"  date_changed="2021-08-22 15:01:14" uuid="6538ad8f-097d-40c7-be5d-c5ef62426b54"/>
-    <concept  concept_id="166471"  retired="0" datatype_id="4"  class_id="5"  is_set="0"  creator="1"  date_created="2021-08-22 14:47:55"  version=""  changed_by="1"  date_changed="2021-08-22 15:03:33" uuid="a22f466d-28b4-435b-9255-378a3feb0ea3"/>
 
 
 
@@ -3813,15 +3807,6 @@
     <concept_name concept_name_id="160170"  concept_id="165139"  name="FTR"  locale="en"  locale_preferred="0"  creator="1"  date_created="2018-09-28 11:58:02"  concept_name_type="SHORT"  voided="0"  uuid="733172c4-c321-11e8-a355-529269fb1459"/>
     <concept_name concept_name_id="160167"  concept_id="165138"  name="FBIM"  locale="en"  locale_preferred="0"  creator="1"  date_created="2018-09-28 11:56:02"  concept_name_type="SHORT"  voided="0"  uuid="733175bc-c321-11e8-a355-529269fb1459"/>
     <concept_name concept_name_id="160168"  concept_id="165138"  name="Facility Based Individual Management"  locale="en"  locale_preferred="1"  creator="1"  date_created="2018-09-28 11:56:02"  concept_name_type="FULLY_SPECIFIED"  voided="0"  uuid="73317832-c321-11e8-a355-529269fb1459"/>
-    <concept_name  concept_name_id="162728"  concept_id="166471"  name="CLDDP"  locale="en"  locale_preferred="0"  creator="1"  date_created="2021-08-22 14:47:55"  concept_name_type="SHORT"  voided="0" uuid="c3493d58-9848-48a8-a77b-e3e45a486a0f"/>
-    <concept_name  concept_name_id="162729"  concept_id="166471"  name="Community Led Drug Distribution Point"  locale="en"  locale_preferred="1"  creator="1"  date_created="2021-08-22 14:47:55"  concept_name_type="FULLY_SPECIFIED"  voided="0" uuid="356cd0f9-d6b4-4f28-86c9-e2a9fbb0c1d5"/>
-    <concept_name  concept_name_id="162731"  concept_id="166472"  name="General CDDP"  locale="en"  locale_preferred="1"  creator="1"  date_created="2021-08-22 15:01:14"  concept_name_type="FULLY_SPECIFIED"  voided="0" uuid="a0b04738-41d1-4e14-aef6-531b0a4bc988"/>
-    <concept_name  concept_name_id="162732"  concept_id="166473"  name="CRPDDP"  locale="en"  locale_preferred="0"  creator="1"  date_created="2021-08-22 15:08:54"  concept_name_type="SHORT"  voided="0" uuid="5c0ff218-cb66-4e27-b507-e3aeb57a62c4"/>
-    <concept_name  concept_name_id="162733"  concept_id="166473"  name="Community Retail Pharmacy Drug Distribution Point"  locale="en"  locale_preferred="1"  creator="1"  date_created="2021-08-22 15:08:54"  concept_name_type="FULLY_SPECIFIED"  voided="0" uuid="b04971a9-04d6-42c2-b3f5-4097e21bca20"/>
-    <concept_name  concept_name_id="162734"  concept_id="166474"  name="Drug Pick Up Model"  locale="en"  locale_preferred="1"  creator="1"  date_created="2021-08-22 15:10:11"  concept_name_type="FULLY_SPECIFIED"  voided="0" uuid="48a545ca-e4bc-4c79-b0be-2bb33c194471"/>
-    <concept_name  concept_name_id="162735"  concept_id="166475"  name="CLDDP Location Name"  locale="en"  locale_preferred="1"  creator="1"  date_created="2021-08-22 15:13:37"  concept_name_type="FULLY_SPECIFIED"  voided="0" uuid="6976eb70-cc9e-47e8-9a5a-f30bd2ee6e17"/>
-    <concept_name  concept_name_id="162736"  concept_id="166476"  name="Pharmacy Code"  locale="en"  locale_preferred="1"  creator="1"  date_created="2021-08-22 15:15:24"  concept_name_type="FULLY_SPECIFIED"  voided="0" uuid="e70955c7-bc65-4eee-a7c7-1151cb9a1533"/>
-
 
 
 
@@ -7026,9 +7011,6 @@
     <concept_answer  concept_answer_id="7087"  concept_id="165143"  answer_concept="165140" creator="1"  date_created="2018-10-15 13:02:40"  sort_weight="2"  uuid="7e9c8a31-3aee-4cd1-b3b8-32d18df2292a"/>
     <concept_answer  concept_answer_id="7090"  concept_id="165143"  answer_concept="165142" creator="1"  date_created="2018-10-15 13:02:40"  sort_weight="5"  uuid="cf6cea6f-c3e7-49f6-a447-15613f36504e"/>
     <concept_answer  concept_answer_id="7086"  concept_id="165143"  answer_concept="165138" creator="1"  date_created="2018-10-15 13:02:40"  sort_weight="1"  uuid="2faf6c05-3a99-41ef-be84-9fca5412b36c"/>
-    <concept_answer  concept_answer_id="7367859"  concept_id="166474"  answer_concept="166473" creator="1"  date_created="2021-08-22 15:10:11"  sort_weight="3"  uuid="1a4463e6-7419-473d-96ba-517b5960e862"/>
-    <concept_answer  concept_answer_id="7367860"  concept_id="166474"  answer_concept="166472" creator="1"  date_created="2021-08-22 15:10:11"  sort_weight="1"  uuid="95c89c42-89b3-45cd-b8ff-57ba6c9fa7ab"/>
-    <concept_answer  concept_answer_id="7367861"  concept_id="166474"  answer_concept="166471" creator="1"  date_created="2021-08-22 15:10:11"  sort_weight="2"  uuid="d123ed51-bedc-47e1-9c55-3cf0a2686c9e"/>
 
     <!--HTS-->
     <concept_answer  concept_answer_id="7135"  concept_id="165169"  answer_concept="162558"   creator="1"  date_created="2019-07-03 16:31:42"  sort_weight="11"  uuid="4bbf6750-6c86-4c6a-8633-fe5c696a8d86"/>

--- a/api/src/main/resources/metadata/Programs.xml
+++ b/api/src/main/resources/metadata/Programs.xml
@@ -10,7 +10,7 @@
 
 
     <!-- CDDP Category -->
-    <program_workflow  program_workflow_id="4"  program_id="9"  concept_id="166474"  creator="1"  date_created="2021-08-25 19:29:37"  retired="0"  changed_by="1"  date_changed="2021-08-25 19:33:56"  uuid="306c02b7-198e-4066-8b2c-39e40a1bcc53"/>
+    <program_workflow  program_workflow_id="4"  program_id="9"  concept_id="166495"  creator="1"  date_created="2021-08-25 19:29:37"  retired="0"  changed_by="1"  date_changed="2021-08-25 19:33:56"  uuid="306c02b7-198e-4066-8b2c-39e40a1bcc53"/>
 
 
     <!--Program Workflow State-->
@@ -39,9 +39,9 @@
 
 
     <!-- CDDP Category -->
-    <program_workflow_state  program_workflow_state_id="14"  program_workflow_id="4"  concept_id="166471"  initial="1"  terminal="0"  creator="1"  date_created="2021-08-25 19:33:45"  retired="0"  changed_by="1"  date_changed="2021-08-25 19:33:56"  uuid="d77cc565-5e53-4633-8fc7-956cfc1831d9"/>
-    <program_workflow_state  program_workflow_state_id="15"  program_workflow_id="4"  concept_id="166473"  initial="1"  terminal="0"  creator="1"  date_created="2021-08-25 19:33:45"  retired="0"  changed_by="1"  date_changed="2021-08-25 19:33:56"  uuid="a6a0ab45-b7dc-43b2-b28c-45a91f968ebf"/>
-    <program_workflow_state  program_workflow_state_id="16"  program_workflow_id="4"  concept_id="166472"  initial="1"  terminal="0"  creator="1"  date_created="2021-08-25 19:33:45"  retired="0"  changed_by="1"  date_changed="2021-08-25 19:33:56"  uuid="1b9b83d4-eaca-40da-a7c6-53b8ea3436ad"/>
+    <program_workflow_state  program_workflow_state_id="14"  program_workflow_id="4"  concept_id="166496"  initial="1"  terminal="0"  creator="1"  date_created="2021-08-25 19:33:45"  retired="0"  changed_by="1"  date_changed="2021-08-25 19:33:56"  uuid="d77cc565-5e53-4633-8fc7-956cfc1831d9"/>
+    <program_workflow_state  program_workflow_state_id="15"  program_workflow_id="4"  concept_id="166498"  initial="1"  terminal="0"  creator="1"  date_created="2021-08-25 19:33:45"  retired="0"  changed_by="1"  date_changed="2021-08-25 19:33:56"  uuid="a6a0ab45-b7dc-43b2-b28c-45a91f968ebf"/>
+    <program_workflow_state  program_workflow_state_id="16"  program_workflow_id="4"  concept_id="166497"  initial="1"  terminal="0"  creator="1"  date_created="2021-08-25 19:33:45"  retired="0"  changed_by="1"  date_changed="2021-08-25 19:33:56"  uuid="1b9b83d4-eaca-40da-a7c6-53b8ea3436ad"/>
 
 
 </dataset>

--- a/api/src/main/resources/metadata/Programs.xml
+++ b/api/src/main/resources/metadata/Programs.xml
@@ -9,6 +9,10 @@
     <program_workflow  program_workflow_id="3"  program_id="1"  concept_id="166214"  creator="1"  date_created="2021-02-05 12:56:14"  retired="0"  changed_by="1"  date_changed="2021-02-05 12:56:14"  uuid="4c30d724-dbcc-42db-ba9b-a9b9d2aadc00"/>
 
 
+    <!-- CDDP Category -->
+    <program_workflow  program_workflow_id="4"  program_id="9"  concept_id="166474"  creator="1"  date_created="2021-08-25 19:29:37"  retired="0"  changed_by="1"  date_changed="2021-08-25 19:33:56"  uuid="306c02b7-198e-4066-8b2c-39e40a1bcc53"/>
+
+
     <!--Program Workflow State-->
     <!--TB Treatment Phase -->
     <program_workflow_state  program_workflow_state_id="1"  program_workflow_id="1"  concept_id="159795"  initial="1"  terminal="0"  creator="1"  date_created="2020-07-29 20:06:21"  retired="0"  uuid="0e2ff228-8dab-491d-9457-aaa47764ef8a"/>
@@ -32,4 +36,12 @@
     <program_workflow_state  program_workflow_state_id="11"  program_workflow_id="3"  concept_id="90271"  initial="0"  terminal="0"  creator="1"  date_created="2020-07-29 20:06:21"  retired="0"  uuid="ab6d1f1d-fcf6-4255-8b6f-2bf8959ad8f2"/>
     <program_workflow_state  program_workflow_state_id="12"  program_workflow_id="3"  concept_id="90305"  initial="0"  terminal="0"  creator="1"  date_created="2020-07-29 20:06:21"  retired="0"  uuid="9a42a3ad-d8a4-4f2e-9fa0-04d5f2e6436e"/>
     <program_workflow_state  program_workflow_state_id="13"  program_workflow_id="3"  concept_id="162987"  initial="0"  terminal="0"  creator="1"  date_created="2020-07-29 21:17:16"  retired="0"  uuid="5d2d0e7e-69a6-408a-b5ce-8d93fb72bc21"/>
+
+
+    <!-- CDDP Category -->
+    <program_workflow_state  program_workflow_state_id="14"  program_workflow_id="4"  concept_id="166471"  initial="1"  terminal="0"  creator="1"  date_created="2021-08-25 19:33:45"  retired="0"  changed_by="1"  date_changed="2021-08-25 19:33:56"  uuid="d77cc565-5e53-4633-8fc7-956cfc1831d9"/>
+    <program_workflow_state  program_workflow_state_id="15"  program_workflow_id="4"  concept_id="166473"  initial="1"  terminal="0"  creator="1"  date_created="2021-08-25 19:33:45"  retired="0"  changed_by="1"  date_changed="2021-08-25 19:33:56"  uuid="a6a0ab45-b7dc-43b2-b28c-45a91f968ebf"/>
+    <program_workflow_state  program_workflow_state_id="16"  program_workflow_id="4"  concept_id="166472"  initial="1"  terminal="0"  creator="1"  date_created="2021-08-25 19:33:45"  retired="0"  changed_by="1"  date_changed="2021-08-25 19:33:56"  uuid="1b9b83d4-eaca-40da-a7c6-53b8ea3436ad"/>
+
+
 </dataset>

--- a/api/src/main/resources/openmrs-distro.properties
+++ b/api/src/main/resources/openmrs-distro.properties
@@ -56,3 +56,4 @@ omod.dataentrystatistics=${dataEntryStatisticsVersion}
 omod.patientflags=${patientFlagsVersion}
 omod.ugandaemrsync=${ugandaemrSyncVersion}
 omod.patientqueueing=${patientqueueingVersion}
+omod.cohort=${cohortModuleVersion}

--- a/omod/src/main/resources/apps/ugandaemr_homepage_app.json
+++ b/omod/src/main/resources/apps/ugandaemr_homepage_app.json
@@ -216,6 +216,22 @@
       "icon": " icon-cog",
       "requiredPrivilege": "App: coreapps.systemAdministration"
     }
+    ]
+   },
+  {
+  "id": "ugandaemr.cohortTypeConfigs",
+  "description": "DSD SubGroup Registration",
+  "order": 40,
+  "extensions": [
+    {
+      "id": "coreapps.activeVisitsHomepageLink",
+      "extensionPointId": "systemAdministration.apps",
+      "type": "link",
+      "label": "DSD SubGroup Configurations",
+      "url": "ugandaemr/CohortRegistration.page",
+      "icon": " icon-cog",
+      "requiredPrivilege": "App: coreapps.systemAdministration"
+    }
   ]
 }
 ]

--- a/omod/src/main/resources/config.xml
+++ b/omod/src/main/resources/config.xml
@@ -257,6 +257,13 @@
         <description>The UUID of the Reception</description>
     </globalProperty>
 
+    <globalProperty>
+        <property>ugandaemr.enableCDDPCategorization</property>
+        <defaultValue>false</defaultValue>
+        <description>This allows a health center to enable other categories of CDDP such as CRPDDP</description>
+        <dataType>org.openmrs.customdatatype.datatype.BooleanDatatype</dataType>
+    </globalProperty>
+
     <privilege>
         <name>Task: HIV Clinic Access</name>
         <description>Able to access HIV patient clinic information</description>

--- a/omod/src/main/webapp/pages/CohortRegistration.gsp
+++ b/omod/src/main/webapp/pages/CohortRegistration.gsp
@@ -63,6 +63,7 @@
                     jq('#description:text').val("");
                     jq('#uuid:text').val("");
                     jq().toastmessage('showSuccessToast', "CDDP Group Saved Successfully");
+                    getCohorts();
                 },
                 error: function (response) {
                     jq().toastmessage('showErrorToast', "Error while Saving CDDP Group");
@@ -77,7 +78,7 @@
         function getCohorts(){
             jq.ajax({
                 type: "GET",
-                url: '/' + OPENMRS_CONTEXT_PATH + "/ws/rest/v1/cohortm/cohort?v=custom:(name,uuid,description)&amp;cohortType=e50fa0af-df36-4a26-853f-feb05244e5ca",
+                url: '/' + OPENMRS_CONTEXT_PATH + "/ws/rest/v1/cohortm/cohort?v=default",
                 dataType: "json",
                 contentType: "application/json",
                 async: false,
@@ -90,27 +91,25 @@
 
         function displaySavedCohorts(data){
             var container = jq('#savedCohortsSections');
-            // container.empty();
-            var table = "<table>" +
-                "<thead>" +
-                "<th>Name</th>" +
-                "<th>Description</th>" +
-                "<th>Identifier</th>" +
-                "<th></th></thead>" +
-                "<tbody>";
+            jq('#savedCohortsSections').empty();
             for (var i = 0; i <data.length; i++) {
-                var id = new String(data[i].uuid);
-                var row = "<tr>" +
-                    "<td>"+data[i].name+"</td>" +
-                    "<td>"+data[i].description+"</td>" +
-                    "<td>"+data[i].uuid+"</td>" +
-                    "<td><input type='button' value='delete' onclick='deleteCohort("+ "\""+ id +"\""+")'/></td>" +
-                    "</tr>";
-                table = table + row;
+                if(data[i].cohortType!=null && data[i].voided==false){
+                    var uuid = new String(data[i].uuid);
+                    var myDate = new Date(data[i].startDate);
+                    var row = "<tr id=\""+uuid+"\">" +
+                        "<td>"+data[i].name+"</td>" +
+                        "<td>"+data[i].description+"</td>" +
+                        "<td>"+data[i].cohortType.name+"</td>" +
+                        "<td>"+myDate.getFullYear()+"-"+myDate.getMonth()+"-"+myDate.getDate()+"</td>" +
+                        "<td>"+uuid+"</td>" +
+                        "<td>" +
+                         "<i style=\"font-size: 25px\" data-toggle=\"modal\" data-target=\"#addEditRefillGroupModal\" class=\"icon-edit edit-action\" title=\"Edit\" onclick=\"editCohort('"+uuid+"')\"></i>" +
+                         "<i style=\"font-size: 25px\"  class=\"delete-item icon-remove\" title=\"Delete\" onclick=\"deleteCohort('"+uuid+"')\"></i></td>" +
+                        "</tr>";
+                    container.append(row);
+                }
+
             }
-            table = table + "</tbody>" +
-            "</table>";
-            container.append(table);
         }
 
         function deleteCohort(id){
@@ -123,17 +122,40 @@
                     async: false,
                     success: function (data) {
                         jq().toastmessage('showSuccessToast', "Cohort Deleted");
+                        getCohorts();
                     }
                 });
             }
         }
 
+        function editCohort(id){
+            var row = jq('#'+id);
+            row.each(function (i) {
+                var tds = jq(this).find('td');
+                   var name = tds.eq(0).text();
+                   var description = tds.eq(1).text();
+                   var type= tds.eq(2).text();
+                   var uuid = tds.eq(4).text();
+
+                jq('#name').attr("value",name);
+                jq('#description').attr("value",description);
+                jq('#uuid').attr("value",uuid);
+                jq("#cohort-type option :selected").removeAttr('selected');
+                jq("#cohort-type option:contains('"+type+"')").attr("selected", "selected");
+
+
+
+            });
+
+
+        }
 
         function submit() {
             var name = jq('#name').val();
             var description = jq('#description').val();
             var unique_id = jq('#uuid').val();
-            var cohort_type = jq('#cohort-type').val();
+            var cohort_type = jq('#cohort-type option:selected').val();
+            console.log(cohort_type);
             var submitVal = true;
 
 
@@ -168,77 +190,124 @@
                 " \"description\": \"" + description + "\"," +
                 " \"uuid\":\"" + unique_id + "\","+
                 " \"cohortType\":\"" + cohort_type + "\","+
-                "\"location\":\"3ec8ff90-3ec1-408e-bf8c-22e4553d6e17\","+
+                "\"location\":\"841cb8d9-b662-41ad-9e7f-d476caac48aa\","+
                 " \"groupCohort\":\"false\","+
                 "\"startDate\":\""+ date + "\"}";
             if(submitVal){
-                saveCohort(dataToPost)
+                saveCohort(dataToPost);
             }
-            console.log(dataToPost);
         }
     }
 </script>
 
-<div id="body-wrapper">
-    <div class="container">
-        <div class="headers" style="text-align: center;">
-            <h3 style="background: #94979A; padding: 10px;">DSD SubGroup Management </h3>
-        </div>
-        <section>
+<div class="card">
+    <div class="card-header">
+        <div class="">
             <div class="row">
-                <div class="col-md-6">
-                    <div class="row">
-                        <div class="col-md-3">
-                            <label>Name:</label>
-                        </div>
-                        <div class="col-md-4">
-                            <input type="text" id="name" name="name"/>
-                        </div>
-                    </div>
-                    <div class="row">
-                        <div class="col-md-3">
-                            <label>Description:</label>
-                        </div>
-                        <div class="col-md-4">
-                            <input type="text" id="description" name="description"/>
-                        </div>
-                    </div>
-                    <div class="row">
-                        <div class="col-md-3">
-                            <label>Identifier No:</label>
-                        </div>
-                        <div class="col-md-4">
-                            <input type="text" id="uuid" name="uuid"/>
-                        </div>
-                    </div>
-                    <div class="row">
-                        <div class="col-md-3">
-                            <label>Group type:</label>
-                        </div>
-                        <div class="col-md-4">
-                            <select name="cohortType" id="cohort-type">
-                                <option>Select ---</option>
-                            </select>
-                        </div>
+                <div class="col-3">
+                    <div>
+                        <h2 style="color: maroon">DSD Refill Groups</h2>
                     </div>
 
-                    <br/>
-                    <input type="button" onclick="submit()" value="Save"/>
+                    <div class="">
+
+                        <button type="button" style="font-size: 25px" class="confirm icon-plus-sign" data-toggle="modal"
+                                data-target="#addEditRefillGroupModal"  data-whatever="@mdo">Create</button>
+                    </div>
+
+                    <div class="vertical"></div>
                 </div>
-                <div class="col-md-6">
-                    <div class="well">
-                        <div id="savedCohortsSections">
 
-                        </div>
-                    </div>
+                <div class="col-8">
+                    <form method="get" id="patient-search-form" onsubmit="return false">
+                        <input type="text" id="patient-search"
+                               placeholder="${ui.message("coreapps.findPatient.search.placeholder")}"
+                               autocomplete="off"/>
+                    </form>
                 </div>
             </div>
-
-        </section>
-
+        </div>
     </div>
 
+    <div class="card-body">
+        <div class="info-body">
+            <table>
+                <thead>
+                <tr>
+                    <th>NAME</th>
+                    <th>Description</th>
+                    <th>Group type</th>
+                    <th>CREATED ON</th>
+                    <th>Identifier</th>
+                    <th>ACTION</th>
+                </tr>
+                </thead>
+                <tbody id="savedCohortsSections">
 
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+
+
+<div class="modal fade" id="addEditRefillGroupModal" tabindex="-1" role="dialog"
+     aria-labelledby="addEditRefillGroup"
+     aria-hidden="true">
+    <div class="modal-dialog  modal-lg" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="addEditRefillGroup">Refill Group</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+
+
+                <input type="hidden" name="syncTaskTypeId" id="syncTaskTypeId" value="">
+
+                <div class="modal-body">
+                    <div class="container">
+                        <div class="row">
+                            <div class="col-6">
+                                <div class="form-group">
+                                    <label>Name:</label>
+                                    <input type="text" class="form-control" id="name" name="name"
+                                           placeholder=" ie CDDP Group Name">
+                                </div>
+
+                                <div class="form-group">
+                                    <label>Description</label>
+                                    <input class="form-control" type="text" id="description" name="description"/>
+
+                                </div>
+
+                                <div class="form-group">
+                                    <label>Identifier Code</label>
+                                    <input class="form-control" type="text" id="uuid" name="uuid"/>
+                                </div>
+                            </div>
+
+
+                            <div class="col-6">
+                                <div class="form-group">
+                                    <label>Group Type</label>
+                                    <select class="form-control" name="cohortType" id="cohort-type">
+                                        <option value="">Select ---</option>
+                                    </select>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                </div>
+
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+                    <input type="button" class="confirm " data-dismiss="modal" value="${ui.message("Save")}" onclick="submit()" />
+                </div>
+        </div>
+    </div>
 </div>
 </body>
 </html>

--- a/omod/src/main/webapp/pages/CohortRegistration.gsp
+++ b/omod/src/main/webapp/pages/CohortRegistration.gsp
@@ -1,0 +1,235 @@
+<%
+    ui.includeFragment("appui", "standardEmrIncludes")
+    ui.includeCss("appui","bootstrap.min.css")
+    ui.includeCss("appui","bootstrap.min.js")
+
+    ui.decorateWith("appui", "standardEmrPage", [ title: ui.message("Cohort Group Registration") ])
+
+    def htmlSafeId = { extension ->
+        "${ extension.id.replace(".", "-") }-${ extension.id.replace(".", "-") }-extension"
+    }
+%>
+
+<!DOCTYPE html>
+<html>
+<head>
+
+</head>
+
+<body>
+<script type="text/javascript">
+    var OPENMRS_CONTEXT_PATH = '${ ui.contextPath() }';
+    var breadcrumbs = [
+        {icon: "icon-home", link: '/' + OPENMRS_CONTEXT_PATH + '/index.htm'},
+        {label: "${ ui.escapeJs(ui.message("Cohort Registration")) }"}
+    ]
+</script>
+
+<script type="text/javascript">
+    if (jQuery) {
+
+        jq(document).ready(function () {
+            getCohorts();
+
+
+            jq.ajax({
+                    type: "GET",
+                    url: '/' + OPENMRS_CONTEXT_PATH + "/ws/rest/v1/cohortm/cohorttype?v=default",
+                    dataType: "json",
+                    contentType: "application/json",
+                    async: false,
+                    success: function (data) {
+                        var types = data.results;
+                        console.log(types);
+                        for (var i = 0; i<types.length; i++) {
+                            jq('#cohort-type').append("<option value='"+ types[i].uuid+"'>"+ types[i].name+ "</option>");
+                        }
+
+                    }
+            });
+
+        });
+        function saveCohort(dataToPost){
+            jq.ajax({
+                type: "POST",
+                url: '/' + OPENMRS_CONTEXT_PATH + "/ws/rest/v1/cohortm/cohort",
+                dataType: "json",
+                contentType: "application/json",
+                accept: "application/json",
+                data: dataToPost,
+                async: false,
+                success: function (data) {
+                    jq('#name:text').val("");
+                    jq('#description:text').val("");
+                    jq('#uuid:text').val("");
+                    jq().toastmessage('showSuccessToast', "CDDP Group Saved Successfully");
+                },
+                error: function (response) {
+                    jq().toastmessage('showErrorToast', "Error while Saving CDDP Group");
+                }
+            });
+        }
+
+        function hasWhiteSpace(s) {
+            return s.indexOf(' ') >= 0;
+        }
+
+        function getCohorts(){
+            jq.ajax({
+                type: "GET",
+                url: '/' + OPENMRS_CONTEXT_PATH + "/ws/rest/v1/cohortm/cohort?v=custom:(name,uuid,description)&amp;cohortType=e50fa0af-df36-4a26-853f-feb05244e5ca",
+                dataType: "json",
+                contentType: "application/json",
+                async: false,
+                success: function (data) {
+                    var cohorts = data.results;
+                    displaySavedCohorts(cohorts);
+                }
+            });
+        }
+
+        function displaySavedCohorts(data){
+            var container = jq('#savedCohortsSections');
+            // container.empty();
+            var table = "<table>" +
+                "<thead>" +
+                "<th>Name</th>" +
+                "<th>Description</th>" +
+                "<th>Identifier</th>" +
+                "<th></th></thead>" +
+                "<tbody>";
+            for (var i = 0; i <data.length; i++) {
+                var id = new String(data[i].uuid);
+                var row = "<tr>" +
+                    "<td>"+data[i].name+"</td>" +
+                    "<td>"+data[i].description+"</td>" +
+                    "<td>"+data[i].uuid+"</td>" +
+                    "<td><input type='button' value='delete' onclick='deleteCohort("+ "\""+ id +"\""+")'/></td>" +
+                    "</tr>";
+                table = table + row;
+            }
+            table = table + "</tbody>" +
+            "</table>";
+            container.append(table);
+        }
+
+        function deleteCohort(id){
+            if(id!==null){
+               console.log(id);
+            }
+        }
+
+
+        function submit() {
+            var name = jq('#name').val();
+            var description = jq('#description').val();
+            var unique_id = jq('#uuid').val();
+            var cohort_type = jq('#cohort-type').val();
+            var submitVal = true;
+
+
+            if (name == ""){
+                submitVal = false;
+                jq().toastmessage('showErrorToast', "CDDP Name is required");
+            }
+
+            if (description== ""){
+                submitVal = false;
+                jq().toastmessage('showErrorToast', "CDDP Description is required");
+            }
+
+            if (unique_id == "") {
+                submitVal = false;
+                jq().toastmessage('showErrorToast', "CDDP unique identifier is required");
+            }
+
+            if (cohort_type == "") {
+                submitVal = false;
+                jq().toastmessage('showErrorToast', "Group Type is required");
+            }
+
+            if(hasWhiteSpace(unique_id)){
+                submitVal = false;
+                jq().toastmessage('showErrorToast', "No spaces are allowed in the unique identifier");
+            }
+
+            var today = new Date();
+            var date = today.getFullYear()+'-'+(today.getMonth()+1)+'-'+today.getDate();
+            var dataToPost = "{\"name\":\"" +  name + "\"," +
+                " \"description\": \"" + description + "\"," +
+                " \"uuid\":\"" + unique_id + "\","+
+                " \"cohortType\":\"" + cohort_type + "\","+
+                "\"location\":\"3ec8ff90-3ec1-408e-bf8c-22e4553d6e17\","+
+                " \"groupCohort\":\"false\","+
+                "\"startDate\":\""+ date + "\"}";
+            if(submitVal){
+                saveCohort(dataToPost)
+            }
+            console.log(dataToPost);
+        }
+    }
+</script>
+
+<div id="body-wrapper">
+    <div class="container">
+        <div class="headers" style="text-align: center;">
+            <h3 style="background: #94979A; padding: 10px;">DSD SubGroup Management </h3>
+        </div>
+        <section>
+            <div class="row">
+                <div class="col-md-6">
+                    <div class="row">
+                        <div class="col-md-3">
+                            <label>Name:</label>
+                        </div>
+                        <div class="col-md-4">
+                            <input type="text" id="name" name="name"/>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-3">
+                            <label>Description:</label>
+                        </div>
+                        <div class="col-md-4">
+                            <input type="text" id="description" name="description"/>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-3">
+                            <label>Identifier No:</label>
+                        </div>
+                        <div class="col-md-4">
+                            <input type="text" id="uuid" name="uuid"/>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-3">
+                            <label>Group type:</label>
+                        </div>
+                        <div class="col-md-4">
+                            <select name="cohortType" id="cohort-type">
+                                <option>Select ---</option>
+                            </select>
+                        </div>
+                    </div>
+
+                    <br/>
+                    <input type="button" onclick="submit()" value="Save"/>
+                </div>
+                <div class="col-md-6">
+                    <div class="well">
+                        <div id="savedCohortsSections">
+
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+        </section>
+
+    </div>
+
+
+</div>
+</body>
+</html>

--- a/omod/src/main/webapp/pages/CohortRegistration.gsp
+++ b/omod/src/main/webapp/pages/CohortRegistration.gsp
@@ -30,29 +30,31 @@
 
         jq(document).ready(function () {
             getCohorts();
-
-
-            jq.ajax({
-                    type: "GET",
-                    url: '/' + OPENMRS_CONTEXT_PATH + "/ws/rest/v1/cohortm/cohorttype?v=default",
-                    dataType: "json",
-                    contentType: "application/json",
-                    async: false,
-                    success: function (data) {
-                        var types = data.results;
-                        console.log(types);
-                        for (var i = 0; i<types.length; i++) {
-                            jq('#cohort-type').append("<option value='"+ types[i].uuid+"'>"+ types[i].name+ "</option>");
-                        }
-
-                    }
-            });
+            getCohortTypes();
 
         });
-        function saveCohort(dataToPost){
+
+        function getCohortTypes(){
+            jq.ajax({
+                type: "GET",
+                url: '/' + OPENMRS_CONTEXT_PATH + "/ws/rest/v1/cohortm/cohorttype?v=default",
+                dataType: "json",
+                contentType: "application/json",
+                async: false,
+                success: function (data) {
+                    var types = data.results;
+
+                    for (var i = 0; i<types.length; i++) {
+                        jq('#cohort-type').append("<option value='"+ types[i].uuid+"'>"+ types[i].name+ "</option>");
+                    }
+
+                }
+            });
+        }
+        function saveCohort(dataToPost,url){
             jq.ajax({
                 type: "POST",
-                url: '/' + OPENMRS_CONTEXT_PATH + "/ws/rest/v1/cohortm/cohort",
+                url: url,
                 dataType: "json",
                 contentType: "application/json",
                 accept: "application/json",
@@ -129,6 +131,8 @@
         }
 
         function editCohort(id){
+            jq("#cohort-type").empty();
+            getCohortTypes()
             var row = jq('#'+id);
             row.each(function (i) {
                 var tds = jq(this).find('td');
@@ -140,17 +144,30 @@
                 jq('#name').attr("value",name);
                 jq('#description').attr("value",description);
                 jq('#uuid').attr("value",uuid);
-                jq("#cohort-type option :selected").removeAttr('selected');
                 jq("#cohort-type option:contains('"+type+"')").attr("selected", "selected");
-
-
-
             });
 
+            jq('.modal-footer > input').attr("onclick","saveEditedData('"+id+"')");
 
         }
 
+        function saveEditedData(id){
+            var dataToPost = processFormData();
+            var url = '/' + OPENMRS_CONTEXT_PATH + "/ws/rest/v1/cohortm/cohort/"+id;
+            if(dataToPost!==""){
+                saveCohort(dataToPost,url);
+            }
+        }
+
         function submit() {
+            var dataToPost = processFormData();
+            var url = '/' + OPENMRS_CONTEXT_PATH + "/ws/rest/v1/cohortm/cohort";
+            if(dataToPost!==""){
+                saveCohort(dataToPost,url);
+            }
+        }
+
+        function processFormData(){
             var name = jq('#name').val();
             var description = jq('#description').val();
             var unique_id = jq('#uuid').val();
@@ -193,9 +210,10 @@
                 "\"location\":\"841cb8d9-b662-41ad-9e7f-d476caac48aa\","+
                 " \"groupCohort\":\"false\","+
                 "\"startDate\":\""+ date + "\"}";
-            if(submitVal){
-                saveCohort(dataToPost);
+            if(submitVal==false){
+                dataToPost="";
             }
+            return dataToPost;
         }
     }
 </script>

--- a/omod/src/main/webapp/pages/CohortRegistration.gsp
+++ b/omod/src/main/webapp/pages/CohortRegistration.gsp
@@ -115,7 +115,16 @@
 
         function deleteCohort(id){
             if(id!==null){
-               console.log(id);
+                jq.ajax({
+                    type: "DELETE",
+                    url: '/' + OPENMRS_CONTEXT_PATH + "/ws/rest/v1/cohortm/cohort/"+id,
+                    dataType: "json",
+                    contentType: "application/json",
+                    async: false,
+                    success: function (data) {
+                        jq().toastmessage('showSuccessToast', "Cohort Deleted");
+                    }
+                });
             }
         }
 

--- a/omod/src/main/webapp/pages/CohortRegistration.gsp
+++ b/omod/src/main/webapp/pages/CohortRegistration.gsp
@@ -78,9 +78,18 @@
         }
 
         function getCohorts(){
+            jq('#savedCohortsSections').empty();
+
+            getCohort("e50fa0af-df36-4a26-853f-feb05244e5ca");
+            getCohort("aa536e57-a3c3-453c-9413-cf70b5d2ad5d");
+            getCohort("5b7136fa-d207-4229-94a8-da6661ae00bf");
+        }
+
+        function getCohort(type){
+
             jq.ajax({
                 type: "GET",
-                url: '/' + OPENMRS_CONTEXT_PATH + "/ws/rest/v1/cohortm/cohort?v=default",
+                url: '/' + OPENMRS_CONTEXT_PATH + "/ws/rest/v1/cohortm/cohort?v=default&cohortType="+type,
                 dataType: "json",
                 contentType: "application/json",
                 async: false,
@@ -93,7 +102,6 @@
 
         function displaySavedCohorts(data){
             var container = jq('#savedCohortsSections');
-            jq('#savedCohortsSections').empty();
             for (var i = 0; i <data.length; i++) {
                 if(data[i].cohortType!=null && data[i].voided==false){
                     var uuid = new String(data[i].uuid);

--- a/omod/src/main/webapp/resources/htmlforms/HMIS-HIV-003-HivCareArtCard-ClinicalAssessmentPage.xml
+++ b/omod/src/main/webapp/resources/htmlforms/HMIS-HIV-003-HivCareArtCard-ClinicalAssessmentPage.xml
@@ -59,6 +59,68 @@
             var latestTransferInEncounter = getLatestEncounterFromEncounterList(transferInEncounters);
             var latestTransferOutEncounter = getLatestEncounterFromEncounterList(transferOutEncounters);
 
+            jq(document).ready(function () {
+
+
+                var enableCDDPCategorization = <lookup expression="fn.globalProperty('ugandaemr.enableCDDPCategorization')"/>;
+
+                if(enableCDDPCategorization===true){
+                    showContainer("#cddp_categorization");
+                }else {
+                    hideContainer("#cddp_categorization");
+                }
+
+                jq("#pharmacy_selection_id").attr("disabled", true);
+                disable_fields("cddp_category");
+                disable_fields("clddp_id");
+                jq.ajax({
+                    type: "GET",
+                    url: '/' + OPENMRS_CONTEXT_PATH + "/ws/rest/v1/location?v=full&amp;&amp;tag=45e82faa-d8c6-4ae0-b52c-d263f8ac9cef",
+                    dataType: "json",
+                    async: false,
+                    success: function (data) {
+
+                        var code_attribute_type_uuid = "3c27cd88-8383-49d4-9072-29b92de60e44";
+                        data.results.forEach(function (location) {
+                            location.attributes.forEach(function (attribute) {
+                                if (attribute.attributeType.uuid === code_attribute_type_uuid) {
+                                    var option = "<option value=" + attribute.value + ">" + location.name + "</option>";
+                                    jq("#pharmacy_selection_id").append(option);
+                                }
+                            })
+
+                        })
+                    }
+                });
+
+                jq("#pharmacy_selection_id").change(function () {
+                    jq("#pharmacy_id input").val(this.value);
+                });
+
+                jq("#cddp_category").change(function () {
+                    var cddpCategory= jq("#cddp_category").find("select").find(":selected").val();
+                    if (cddpCategory === "a6a0ab45-b7dc-43b2-b28c-45a91f968ebf") {
+                        jq("#pharmacy_selection_id").attr("disabled", false);
+                        disable_fields("clddp_id");
+                    } else if (cddpCategory === "d77cc565-5e53-4633-8fc7-956cfc1831d9") {
+                        enable_fields("clddp_id");
+                        jq("#pharmacy_selection_id").attr("disabled", true);
+                    }else {
+                        jq("#pharmacy_selection_id").attr("disabled", true);
+                        disable_fields("clddp_id");
+                    }
+                });
+
+                jq("#165143 select").change(function () {
+                    if (jq("#165143").find("select").find(":selected").val() === "165142") {
+                        enable_fields("cddp_category");
+                    }else {
+                        disable_fields("cddp_category");
+                    }
+                });
+            });
+
+
             function getEncountersByEncounterTypeUUID(patientUUID,encounterTypeUUID){
                 var serverResponse =[];
                 jq.ajax({
@@ -2664,6 +2726,34 @@
                                             </div>
                                         </div>
 
+                                        <div id="cddp_categorization" class="card">
+                                            <div class="card-header">Drug Pick Up Model</div>
+                                            <div class="card-body">
+                                                <div class="row">
+                                                    <div class="col-md-3" id="cddp_category">
+                                                        <label>CDDP Category"</label>
+                                                        <workflowState  workflowId="4" stateIds="16,14,15" stateLabels="General CDDP, CLDDP,CRPDDP"/>
+                                                    </div>
+                                                    <div class="col-md-3">
+                                                        <label>Pharmacy</label>
+                                                        <div class="form-group">
+                                                            <select class="form-control" id="pharmacy_selection_id" name="pharmacy_selection_id">
+                                                                <option value="">Select Pharmacy</option>
+                                                            </select>
+                                                        </div>
+                                                    </div>
+                                                    <div class="col-md-3">
+                                                        <obs id="pharmacy_id" conceptId="166476"
+                                                             labelText="Pharmacy Code"/>
+                                                    </div>
+                                                    <div class="col-md-3">
+                                                        <obs id="clddp_id" conceptId="166475"
+                                                             labelText="CLDDP Location"/>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+
                                         <div class="card">
                                             <div class="card-header">Transfer Out</div>
                                             <div class="card-body">
@@ -3735,6 +3825,34 @@
                                     <obs conceptId="160288" answerConceptIds="164969,165284"
                                          answerLabels="R - Drug Refill ONLY, C - Clinical Assessment/Drug refill and/or Tests/Investigations"
                                          style="radio" class="horizontal"/>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div id="cddp_categorization" class="card">
+                        <div class="card-header">Drug Pick Up Model</div>
+                        <div class="card-body">
+                            <div class="row">
+                                <div class="col-md-3" id="cddp_category">
+                                    <label>CDDP Category"</label>
+                                    <workflowState  workflowId="4" stateIds="16,14,15" stateLabels="General CDDP, CLDDP,CRPDDP"/>
+                                </div>
+                                <div class="col-md-3">
+                                    <label>Pharmacy</label>
+                                    <div class="form-group">
+                                        <select class="form-control" id="pharmacy_selection_id" name="pharmacy_selection_id">
+                                            <option value="">Select Pharmacy</option>
+                                        </select>
+                                    </div>
+                                </div>
+                                <div class="col-md-3">
+                                    <obs id="pharmacy_id" conceptId="166476"
+                                         labelText="Pharmacy Code"/>
+                                </div>
+                                <div class="col-md-3">
+                                    <obs id="clddp_id" conceptId="166475"
+                                         labelText="CLDDP Location"/>
                                 </div>
                             </div>
                         </div>

--- a/omod/src/main/webapp/resources/htmlforms/HMIS-HIV-003-HivCareArtCard-ClinicalAssessmentPage.xml
+++ b/omod/src/main/webapp/resources/htmlforms/HMIS-HIV-003-HivCareArtCard-ClinicalAssessmentPage.xml
@@ -101,6 +101,9 @@
                     if (jq("#165143").find("select").find(":selected").val() === "165142") {
                         enable_fields("cddp_category");
                     }else {
+                        setValue('refill_point_id.value','');
+                        jq("#refill_point_select_id  option").prop("selected", false);
+                        jq("#cddp_category  option").prop("selected", false);
                         disable_fields("cddp_category");
                     }
                 });

--- a/omod/src/main/webapp/resources/htmlforms/HMIS-HIV-003-HivCareArtCard-ClinicalAssessmentPage.xml
+++ b/omod/src/main/webapp/resources/htmlforms/HMIS-HIV-003-HivCareArtCard-ClinicalAssessmentPage.xml
@@ -2774,7 +2774,7 @@
                                                         </div>
                                                     </div>
                                                     <div class="col-md-3">
-                                                        <obs id="refill_point_id" conceptId="166476"
+                                                        <obs id="refill_point_id" conceptId="166500"
                                                              labelText="DSD Group Code"/>
                                                     </div>
                                                 </div>

--- a/omod/src/main/webapp/resources/htmlforms/HMIS-HIV-003-HivCareArtCard-ClinicalAssessmentPage.xml
+++ b/omod/src/main/webapp/resources/htmlforms/HMIS-HIV-003-HivCareArtCard-ClinicalAssessmentPage.xml
@@ -70,44 +70,26 @@
                     hideContainer("#cddp_categorization");
                 }
 
-                jq("#pharmacy_selection_id").attr("disabled", true);
+                jq("#refill_point_select_id").attr("disabled", true);
                 disable_fields("cddp_category");
-                disable_fields("clddp_id");
-                jq.ajax({
-                    type: "GET",
-                    url: '/' + OPENMRS_CONTEXT_PATH + "/ws/rest/v1/location?v=full&amp;&amp;tag=45e82faa-d8c6-4ae0-b52c-d263f8ac9cef",
-                    dataType: "json",
-                    async: false,
-                    success: function (data) {
 
-                        var code_attribute_type_uuid = "3c27cd88-8383-49d4-9072-29b92de60e44";
-                        data.results.forEach(function (location) {
-                            location.attributes.forEach(function (attribute) {
-                                if (attribute.attributeType.uuid === code_attribute_type_uuid) {
-                                    var option = "<option value=" + attribute.value + ">" + location.name + "</option>";
-                                    jq("#pharmacy_selection_id").append(option);
-                                }
-                            })
 
-                        })
-                    }
-                });
-
-                jq("#pharmacy_selection_id").change(function () {
-                    jq("#pharmacy_id input").val(this.value);
+                jq("#refill_point_select_id").change(function () {
+                    jq("#refill_point_id input").val(this.value);
                 });
 
                 jq("#cddp_category").change(function () {
                     var cddpCategory= jq("#cddp_category").find("select").find(":selected").val();
                     if (cddpCategory === "a6a0ab45-b7dc-43b2-b28c-45a91f968ebf") {
-                        jq("#pharmacy_selection_id").attr("disabled", false);
-                        disable_fields("clddp_id");
+<!--                            CRPDDP categories fetching-->
+                        jq("#refill_point_select_id").attr("disabled", false);
+                        getCohortCategorizations("e50fa0af-df36-4a26-853f-feb05244e5ca");
                     } else if (cddpCategory === "d77cc565-5e53-4633-8fc7-956cfc1831d9") {
-                        enable_fields("clddp_id");
-                        jq("#pharmacy_selection_id").attr("disabled", true);
+<!--                            CLDDP categories fetching -->
+                        jq("#refill_point_select_id").attr("disabled", false);
+                        getCohortCategorizations("aa536e57-a3c3-453c-9413-cf70b5d2ad5d");
                     }else {
-                        jq("#pharmacy_selection_id").attr("disabled", true);
-                        disable_fields("clddp_id");
+                        jq("#refill_point_select_id").attr("disabled", true);
                     }
                 });
 
@@ -146,6 +128,25 @@
                 }else {
                     return false;
                 }
+            }
+
+            function getCohortCategorizations(uuid){
+                jq('#refill_point_select_id').empty();
+                jq.ajax({
+                    type: "GET",
+                    url: '/' + OPENMRS_CONTEXT_PATH + "/ws/rest/v1/cohortm/cohort?v=custom:(name,uuid,description)&amp;cohortType=" + uuid,
+                    dataType: "json",
+                    contentType: "application/json",
+                    async: false,
+                    success: function (data) {
+                    var cohorts = data.results;
+                    jq('#refill_point_select_id').append($("<option>Select Refill Point</option>"));
+                        for (var i = 0; i &lt; cohorts.length; i++) {
+                                jq('#refill_point_select_id').append($("<option></option>").attr("value", cohorts[i].uuid).text(cohorts[i].name));
+                        }
+
+                    }
+                });
             }
 
            jq(document).ready(function () {
@@ -1364,6 +1365,30 @@
                 }
 
             </restrictByRole>
+
+            var cohort = getValue('refill_point_id.value');
+            var date = encounterDate.getFullYear()+'-'+(encounterDate.getMonth()+1)+'-'+encounterDate.getDate();
+            var DSDCategory = getValue('cddp_category.value');
+            var dataToPost = "{\"patient\": \"" +  patientUUID + "\", \"cohort\": \"" + cohort + "\",\"startDate\": \"" + date+ "\"}";
+            if (cohort == "" &amp;&amp; (DSDCategory==="a6a0ab45-b7dc-43b2-b28c-45a91f968ebf" || DSDCategory==="d77cc565-5e53-4633-8fc7-956cfc1831d9")){
+                jq().toastmessage('showErrorToast', "Select at least a DSD Refill for this client");
+                return false;
+            }else{
+                jq.ajax({
+                type: "POST",
+                url: '/' + OPENMRS_CONTEXT_PATH + "/ws/rest/v1/cohortm/cohortmember/",
+                dataType: "json",
+                contentType: "application/json",
+                accept: "application/json",
+                data: dataToPost,
+                success: function (data) {
+                    jq().toastmessage('showSuccessToast', "Client Added to a Refill Group Successfully");
+                },
+                error: function (response) {
+                    jq().toastmessage('showErrorToast', "Error while Added Client to Refill Group");
+                }
+                });
+            }
 
                 return true;
             });
@@ -2735,20 +2760,16 @@
                                                         <workflowState  workflowId="4" stateIds="16,14,15" stateLabels="General CDDP, CLDDP,CRPDDP"/>
                                                     </div>
                                                     <div class="col-md-3">
-                                                        <label>Pharmacy</label>
+                                                       <label>DSD Group Refill Point</label>
                                                         <div class="form-group">
-                                                            <select class="form-control" id="pharmacy_selection_id" name="pharmacy_selection_id">
-                                                                <option value="">Select Pharmacy</option>
+                                                            <select class="form-control" id="refill_point_select_id" name="refill_point_select_id">
+                                                                <option value="">Select Refill Point</option>
                                                             </select>
                                                         </div>
                                                     </div>
                                                     <div class="col-md-3">
-                                                        <obs id="pharmacy_id" conceptId="166476"
-                                                             labelText="Pharmacy Code"/>
-                                                    </div>
-                                                    <div class="col-md-3">
-                                                        <obs id="clddp_id" conceptId="166475"
-                                                             labelText="CLDDP Location"/>
+                                                        <obs id="refill_point_id" conceptId="166476"
+                                                             labelText="DSD Group Code"/>
                                                     </div>
                                                 </div>
                                             </div>
@@ -3839,20 +3860,16 @@
                                     <workflowState  workflowId="4" stateIds="16,14,15" stateLabels="General CDDP, CLDDP,CRPDDP"/>
                                 </div>
                                 <div class="col-md-3">
-                                    <label>Pharmacy</label>
+                                   <label>DSD Group Refill Point</label>
                                     <div class="form-group">
-                                        <select class="form-control" id="pharmacy_selection_id" name="pharmacy_selection_id">
-                                            <option value="">Select Pharmacy</option>
+                                        <select class="form-control" id="refill_point_select_id" name="refill_point_select_id">
+                                            <option value="">Select A refill Point</option>
                                         </select>
                                     </div>
                                 </div>
                                 <div class="col-md-3">
-                                    <obs id="pharmacy_id" conceptId="166476"
-                                         labelText="Pharmacy Code"/>
-                                </div>
-                                <div class="col-md-3">
-                                    <obs id="clddp_id" conceptId="166475"
-                                         labelText="CLDDP Location"/>
+                                    <obs id="refill_point_id" conceptId="166476"
+                                         labelText="DSD Group Code"/>
                                 </div>
                             </div>
                         </div>

--- a/omod/src/main/webapp/resources/htmlforms/HMIS-HIV-003-HivCareArtCard-ClinicalAssessmentPage.xml
+++ b/omod/src/main/webapp/resources/htmlforms/HMIS-HIV-003-HivCareArtCard-ClinicalAssessmentPage.xml
@@ -63,7 +63,7 @@
 
 
                 var enableCDDPCategorization = <lookup expression="fn.globalProperty('ugandaemr.enableCDDPCategorization')"/>;
-
+                fieldHelper.makeReadonly(getField('refill_point_id.value'));
                 if(enableCDDPCategorization===true){
                     showContainer("#cddp_categorization");
                 }else {
@@ -80,15 +80,19 @@
 
                 jq("#cddp_category").change(function () {
                     var cddpCategory= jq("#cddp_category").find("select").find(":selected").val();
+                    setValue('refill_point_id.value','');
                     if (cddpCategory === "a6a0ab45-b7dc-43b2-b28c-45a91f968ebf") {
 <!--                            CRPDDP categories fetching-->
+                        jq('#refill_point_select_id').parent('div').parent('div').find('label').html('Pharmacy');
                         jq("#refill_point_select_id").attr("disabled", false);
                         getCohortCategorizations("e50fa0af-df36-4a26-853f-feb05244e5ca");
                     } else if (cddpCategory === "d77cc565-5e53-4633-8fc7-956cfc1831d9") {
 <!--                            CLDDP categories fetching -->
+                        jq('#refill_point_select_id').parent('div').parent('div').find('label').html('CLDDP Group');
                         jq("#refill_point_select_id").attr("disabled", false);
                         getCohortCategorizations("aa536e57-a3c3-453c-9413-cf70b5d2ad5d");
                     }else {
+                        jq('#refill_point_select_id').parent('div').parent('div').find('label').html('DSD Refill Group');
                         jq("#refill_point_select_id").attr("disabled", true);
                     }
                 });
@@ -134,15 +138,17 @@
                 jq('#refill_point_select_id').empty();
                 jq.ajax({
                     type: "GET",
-                    url: '/' + OPENMRS_CONTEXT_PATH + "/ws/rest/v1/cohortm/cohort?v=custom:(name,uuid,description)&amp;cohortType=" + uuid,
+                    url: '/' + OPENMRS_CONTEXT_PATH + "/ws/rest/v1/cohortm/cohort?v=custom:(name,uuid,description,voided)&amp;cohortType=" + uuid,
                     dataType: "json",
                     contentType: "application/json",
                     async: false,
                     success: function (data) {
                     var cohorts = data.results;
-                    jq('#refill_point_select_id').append($("<option>Select Refill Point</option>"));
+                    jq('#refill_point_select_id').append($("<option ></option>").attr("value",''));
                         for (var i = 0; i &lt; cohorts.length; i++) {
+                            if(cohorts[i].voided===false){
                                 jq('#refill_point_select_id').append($("<option></option>").attr("value", cohorts[i].uuid).text(cohorts[i].name));
+                            }
                         }
 
                     }
@@ -2756,7 +2762,7 @@
                                             <div class="card-body">
                                                 <div class="row">
                                                     <div class="col-md-3" id="cddp_category">
-                                                        <label>CDDP Category"</label>
+                                                        <label>CDDP Category</label>
                                                         <workflowState  workflowId="4" stateIds="16,14,15" stateLabels="General CDDP, CLDDP,CRPDDP"/>
                                                     </div>
                                                     <div class="col-md-3">
@@ -3856,14 +3862,14 @@
                         <div class="card-body">
                             <div class="row">
                                 <div class="col-md-3" id="cddp_category">
-                                    <label>CDDP Category"</label>
+                                    <label>CDDP Category</label>
                                     <workflowState  workflowId="4" stateIds="16,14,15" stateLabels="General CDDP, CLDDP,CRPDDP"/>
                                 </div>
                                 <div class="col-md-3">
                                    <label>DSD Group Refill Point</label>
                                     <div class="form-group">
                                         <select class="form-control" id="refill_point_select_id" name="refill_point_select_id">
-                                            <option value="">Select A refill Point</option>
+                                            <option value="">Select Refill Point</option>
                                         </select>
                                     </div>
                                 </div>

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
 		<dataintegrityVersion>4.4.3</dataintegrityVersion>
 		<emrapiVersion>1.29.0</emrapiVersion>
 		<eventVersion>2.7.0</eventVersion>
-		<fhir2Version>1.1.0</fhir2Version>
+		<fhir2Version>1.2.2</fhir2Version>
 		<formentryappVersion>1.4.2</formentryappVersion>
 		<formfilterVersion>1.0.0</formfilterVersion>
 		<htmlformentryuiVersion>1.10.0</htmlformentryuiVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -115,6 +115,7 @@
 		<patientqueueingVersion>1.2.0</patientqueueingVersion>
 		<ugandaemrSyncVersion>1.0.11-SNAPSHOT</ugandaemrSyncVersion>
 		<ugandaemrfingerprintVersion>1.0.11</ugandaemrfingerprintVersion>
+		<cohortModuleVersion>3.0.0-SNAPSHOT</cohortModuleVersion>
 
 		<!-- core configuration library -->
 		<ugandaemrReportsVersion>2.0.26-SNAPSHOT</ugandaemrReportsVersion>
@@ -461,6 +462,11 @@
 				<scope>provided</scope>
 				<type>test-jar</type>
     		</dependency>
+			<dependency>
+				<groupId>org.openmrs.module</groupId>
+				<artifactId>cohort</artifactId>
+				<version>${cohortModuleVersion}</version>
+			</dependency>
 		</dependencies>
 	</dependencyManagement>
 


### PR DESCRIPTION
How to test 
-Administrator is able to register register cohorts of a particular Cohort type via Home>System administration >DSD SubGroup Configuration
-Enable CDDP Categorization in ugandaemr global properties
-On the encounter page under DSD tab, once a patient is able to go on CDDP, you can further categorise him under CRPDDP or CLDDP. On picking any of the groups, the DSD Group-Refill Point drop down fills with the cohorts registered under that sub category 
-The unique identifier of that cohort is displayed in the DSD Group Code field 
-On saving the encounter a client is added to the assigned  cohort and identifier code also saved as an obs 
Note : This PR is built on top of https://github.com/METS-Programme/openmrs-module-ugandaemr/pull/100 which is implemented not  based Cohort assignment but rather on Locations 