### PR TITLE
Fix inclusion of API resources twice in the pom 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -548,7 +548,7 @@
 								<includeGroupIds>${project.parent.groupId}</includeGroupIds>
 								<includeArtifactIds>${project.parent.artifactId}-api</includeArtifactIds>
 								<excludeTransitive>true</excludeTransitive>
-								<includes>**/*</includes>
+								<includes>**\/*.xml,**\/*.properties</includes>
 								<outputDirectory>${project.build.directory}/classes</outputDirectory>
 							</configuration>
 						</execution>


### PR DESCRIPTION
as per https://talk.openmrs.org/t/most-poms-configured-to-include-api-artifacts-twice-in-the-pom/35257

https://app.asana.com/0/1133167201254913/1201445963728403/f