### PR TITLE
Fix Stability criteria that allow 1 year instead of 6 months in dsdm to a dynamic regimen duration requirement 

### DIFF
--- a/omod/src/main/java/org/openmrs/module/ugandaemr/fragment/controller/PatientStabilityFragmentController.java
+++ b/omod/src/main/java/org/openmrs/module/ugandaemr/fragment/controller/PatientStabilityFragmentController.java
@@ -26,6 +26,7 @@ public class PatientStabilityFragmentController {
         ObsService obsService = Context.getObsService();
         ConceptService conceptService = Context.getConceptService();
         PatientService patientService = Context.getPatientService();
+        Integer minimumDurationOnCurrentRegimen = Integer.parseInt(Context.getAdministrationService().getGlobalProperty("ugandaemr.dsdm.currentRegimenDurationRequirementInMonths"));
 
         Visit encounterVisit = new Visit();
         if (visit == null && encounter != null) {
@@ -61,7 +62,7 @@ public class PatientStabilityFragmentController {
         /**
          * Current regimen
          */
-        int monthOffSet = -12;
+        int monthOffSet = -minimumDurationOnCurrentRegimen;
 
         Obs obs=getMostRecentObservation(encounterVisit,"90315");
 


### PR DESCRIPTION
https://app.asana.com/0/1133167201254913/1201478229273820
Fix Stability criteria that allow 1 year instead of 6 months in dsdm to a dynamic regimen duration requirement 