### PR TITLE
Make return date mandatory and transfer out date and location required if patient is transferred out

### DIFF
--- a/omod/src/main/webapp/resources/htmlforms/HMIS-HIV-003-HivCareArtCard-ClinicalAssessmentPage.xml
+++ b/omod/src/main/webapp/resources/htmlforms/HMIS-HIV-003-HivCareArtCard-ClinicalAssessmentPage.xml
@@ -161,35 +161,6 @@
                 });
             }
 
-            //Return visit date is required if there is no transfer out
-            <!-- jq(document).ready(function () { 
-
-                jq(".transfer_out").change(function () {
-
-                    if(jq(this).find("input[type$='checkbox']:checked").val() =="90003") {
-                        returnVisitDateIsRequired = 'false';
-                    }
-                    else 
-                        returnVisitDateIsRequired = 'true';
-                });
-            }); -->
-
-
-            //Non POC mode: Return visit date is required if there is no transfer out
-            <!-- jq(document).ready(function () { 
-
-                jq(".transfer_out").change(function () {
-
-                    if(jq(this).find("input[type$='checkbox']:checked").val() =="90003") {
-                        
-                        jq(".returndate span").removeClass("required");
-                        //jq(".returndate span span error field-error").css("display", "none");
-                    }
-                    else 
-                        jq(".returndate span").addClass("required");
-                });
-            }); -->
-
             //Check if any prescription is made, if so that return date will be mandatory
             jq(document).ready(function () { 
 
@@ -252,8 +223,7 @@
                 jq(contentAddId).toggle(false);
                 jq(':input:not(:button)', contentAddId).val([]);
                 jq('#' + correctedRemoveButtonId + '-addEntry-other').toggle(true);
-                jq('#' + correctedRemoveButtonId + '-removeEntry-other').toggle(true);prescription-poc
-
+                jq('#' + correctedRemoveButtonId + '-removeEntry-other').toggle(true);
                 return false;
                 });
 
@@ -1038,8 +1008,6 @@
 
                 /*enable disable Hepatitis B status*/
 
-
-
                 jq(".hepB-status").change(function () {
                     var hepStatus = jq(this).find("input[type='radio']:checked").val();
                     if (hepStatus == 159971) {
@@ -1264,7 +1232,7 @@
                     return false;
                 }
 
-                //Return visit date is mandatory if any prescription is made
+                //Return visit date is required if any prescription is made
                 if(prescription=="true" &amp;&amp; returnDate=="") {
                     jq().toastmessage('showErrorToast', "The return visit date is required");
                     return false;
@@ -1283,6 +1251,7 @@
                     } 
                 }
 
+                //Return visit date is required if there is no transfer out in non POC mode
                 if(transferOut !==90003 &amp;&amp; returnDatePoc =="") {
                     jq().toastmessage('showErrorToast', "The return visit date is required");
                     return false;

--- a/omod/src/main/webapp/resources/htmlforms/HMIS-HIV-003-HivCareArtCard-ClinicalAssessmentPage.xml
+++ b/omod/src/main/webapp/resources/htmlforms/HMIS-HIV-003-HivCareArtCard-ClinicalAssessmentPage.xml
@@ -231,9 +231,6 @@
 
         });
 
-
-
-
         jq(document).ready(function () {
                 $allRows = jq(this).find('.multi-drug');
                 $allRows.hide();
@@ -1191,16 +1188,33 @@
                 var appointment = new Date((jq("#returndate").find('input[type=hidden]').val()));
                 var transferOutDate = new Date((getValue('transfer_out_date.value')));
 
-                if(getValue('provider.value')==""){
-                     jq().toastmessage('showErrorToast', "Attending clinician is required");
-                 }
+                if(getValue('returndate.value')==""){
+                    jq().toastmessage('showErrorToast', "The return date is required");
+                    return false;
+                }
 
-                if (encounterDate &gt;= appointment) {
+                if(getValue('provider.value')==""){
+                    jq().toastmessage('showErrorToast', "Attending clinician is required");
+                }
+
+                if(encounterDate &gt;= appointment){
                     getField('returndate.error').html('The return date must be after the date of this visit ' +
                         formatDateForDisplay(encounterDate)).show();
                     jq().toastmessage('showErrorToast', "The return date must be after the date of this visit");
                     return false;
+                }
 
+                if(jq('.transfer_out').find("input[type$='checkbox']:checked").val() == 90003) {
+
+                    if(getValue('transfer_out_date.value')==""){
+                        jq().toastmessage('showErrorToast', "The transfer out date is required");
+                        return false;
+                    }
+
+                    if(getValue('transfer_out_location.value')==""){
+                        jq().toastmessage('showErrorToast', "Transfer out place/facility is required");
+                        return false;
+                    } 
                 }
 
                 if(getValue('transfer_out_date.value') !== "" &amp;&amp; encounterDate.getTime() !== transferOutDate.getTime()){
@@ -1665,12 +1679,12 @@
                                                                             complexExpression="#set($transfer_out_date=($fn.latestObs('99165').valueDatetime)) #set($lost_to_follow_date=$fn.latestObs('99165').valueDatetime) #set($transfer_out=$fn.latestObs('90306').valueCoded.name) $transfer_out_date"/>
                                                                 </span>
                                                                 <includeIf velocityTest="$transfer_out=='YES'">
-                                                                    <label>Return date</label>
+                                                                    <label><span class="required">*</span>Return date</label>
                                                                     <obs id="returndate" conceptId="5096"
-                                                                         allowFutureDates="true"/>
+                                                                         allowFutureDates="true" required="required"/>
                                                                 </includeIf>
                                                                 <includeIf velocityTest="$transfer_out!='YES'">
-                                                                    <label>Return date</label>
+                                                                    <label><span class="required">*</span>Return date</label>
                                                                     <obs id="returndate" conceptId="5096"
                                                                          required="required" allowFutureDates="true"/>
                                                                 </includeIf>
@@ -1681,12 +1695,12 @@
                                                                             complexExpression="#set($transfer_out_date=($fn.latestObs('99165').valueDatetime)) #set($lost_to_follow_date=$fn.latestObs('99165').valueDatetime) #set($transfer_out=$fn.latestObs('90306').valueCoded.name) $transfer_out_date"/>
                                                                 </span>
                                                                 <includeIf velocityTest="$transfer_out=='YES'">
-                                                                    <label>Return date</label>
+                                                                    <label><span class="required">*</span>Return date</label>
                                                                     <obs id="returndate" conceptId="5096"
-                                                                         allowFutureDates="true"/>
+                                                                         allowFutureDates="true" required="required"/>
                                                                 </includeIf>
                                                                 <includeIf velocityTest="$transfer_out!='YES'">
-                                                                    <label>Return date</label>
+                                                                    <label><span class="required">*</span>Return date</label>
                                                                     <obs id="returndate" conceptId="5096"
                                                                          required="required" allowFutureDates="true"/>
                                                                 </includeIf>
@@ -2797,13 +2811,13 @@
                                                 <div class="row">
                                                     <div class="col-md-4" id="final-out-come">
                                                         <obs id="transfer_out" conceptId="90306" answerConceptId="90003"
-                                                             answerLabel="Transfer out"/>
+                                                             answerLabel="Transfer out" class="transfer_out"/>
                                                     </div>
                                                     <div class="col-md-4" id="disabled">
-                                                        <obs id="transfer_out_date" conceptId="99165" labelText="Date of Transfer"/>
+                                                        <obs id="transfer_out_date" conceptId="99165" labelText="Date of Transfer" class="transfer_out_date"/>
                                                     </div>
                                                     <div class="col-md-4" id="disabled">
-                                                        <obs id="transfer_out_location" conceptId="90211" labelText="Where"/>
+                                                        <obs id="transfer_out_location" conceptId="90211" labelText="Where" class="transfer_out_location"/>
                                                     </div>
                                                 </div>
                                                 </obsgroup>
@@ -2876,7 +2890,12 @@
                         <div class="card-header">
                             <ul class="nav nav-tabs card-header-tabs nav-fill">
                                 <li class="nav-item">
-                                    <a class="nav-link active" data-toggle="tab" href="#patient-vitals">
+                                    <a class="nav-link active" data-toggle="tab" href="#return-date">
+                                        Return Date
+                                    </a>
+                                </li>
+                                <li class="nav-item">
+                                    <a class="nav-link" data-toggle="tab" href="#patient-vitals">
                                         Triage Information
                                     </a>
                                 </li>
@@ -2896,10 +2915,32 @@
                             </ul>
                         </div>
 
-                        <div class="card-body">
-                            <div class="tab-content">
+                            <div class="card-body">
+                                <div class="tab-content">
+                                <div class="tab-pane fade show active" id="return-date" >
+                                    <div class="row">
+                                        <div class="col-md-4">
+                                            <excludeIf velocityTest="$patient.person.dead ==true">
+                                                <lookup complexExpression="#set($transfer_out_date = '')"/>
+                                                <span id="transfer_out_date_id" class="hidden">
+                                                    <lookup
+                                                            complexExpression="#set($transfer_out_date=($fn.latestObs('99165').valueDatetime)) #set($lost_to_follow_date=$fn.latestObs('99165').valueDatetime) #set($transfer_out=$fn.latestObs('90306').valueCoded.name) $transfer_out_date"/>
+                                                </span>
+                                                <includeIf velocityTest="$transfer_out=='YES'">
+                                                    <label><span class="required">*</span>Return date</label>
+                                                        <obs id="returndate" conceptId="5096"
+                                                        required="required" allowFutureDates="true"/>
+                                                </includeIf>
 
-                                <div class="tab-pane fade show active" id="patient-vitals" >
+                                                <includeIf velocityTest="$transfer_out!='YES'">
+                                                    <label><span class="required">*</span>Return date</label>
+                                                        <obs id="returndate" conceptId="5096"                                                                required="required" allowFutureDates="true"/>
+                                                </includeIf>
+                                            </excludeIf>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="tab-pane fade show" id="patient-vitals" >
                                     <uiInclude provider="ugandaemr" fragment="vitals"/>
                                 </div>
                                 <div class="tab-pane fade" id="nav-family-planning" role="tabpanel" >
@@ -3927,38 +3968,18 @@
                                         </div>
                                     </div>
                                 </div>
-                                <div class="row">
-                                    <div class="col-md-4">
-                                        <excludeIf velocityTest="$patient.person.dead ==true">
-                                            <lookup complexExpression="#set($transfer_out_date = '')"/>
-                                            <span id="transfer_out_date_id" class="hidden">
-                                                <lookup
-                                                        complexExpression="#set($transfer_out_date=($fn.latestObs('99165').valueDatetime)) #set($lost_to_follow_date=$fn.latestObs('99165').valueDatetime) #set($transfer_out=$fn.latestObs('90306').valueCoded.name) $transfer_out_date"/>
-                                            </span>
-                                            <includeIf velocityTest="$transfer_out=='YES'">
-                                                <obs id="returndate" conceptId="5096" allowFutureDates="true"
-                                                     labelText="Return date"/>
-                                            </includeIf>
-
-                                            <includeIf velocityTest="$transfer_out!='YES'">
-                                                <obs id="returndate" conceptId="5096" required="required"
-                                                     allowFutureDates="true"
-                                                     labelText="Return date"/>
-                                            </includeIf>
-                                        </excludeIf>
-                                    </div>
-                                </div>
+                                
                                 <obsgroup groupingConceptId="99166">
                                     <div class="row">
                                         <div class="col-md-4" id="final-out-come">
                                             <obs id="transfer_out" conceptId="90306" answerConceptId="90003"
-                                                 answerLabel="Transfer out"/>
+                                                 answerLabel="Transfer out" class="transfer_out"/>
                                         </div>
                                         <div class="col-md-4" id="disabled">
-                                            <obs id="transfer_out_date" conceptId="99165" labelText="Date of Transfer"/>
+                                            <obs id="transfer_out_date" conceptId="99165" labelText="Date of Transfer" class="transfer_date"/>
                                         </div>
                                         <div class="col-md-4" id="disabled">
-                                            <obs id="transfer_out_location" conceptId="90211" labelText="Where"/>
+                                            <obs id="transfer_out_location" conceptId="90211" labelText="Where" class="transfer_out_location"/>
                                         </div>
                                     </div>
                                 </obsgroup>

--- a/omod/src/main/webapp/resources/htmlforms/HMIS-HIV-003-HivCareArtCard-ClinicalAssessmentPage.xml
+++ b/omod/src/main/webapp/resources/htmlforms/HMIS-HIV-003-HivCareArtCard-ClinicalAssessmentPage.xml
@@ -59,6 +59,9 @@
             var latestTransferInEncounter = getLatestEncounterFromEncounterList(transferInEncounters);
             var latestTransferOutEncounter = getLatestEncounterFromEncounterList(transferOutEncounters);
 
+            var prescription = 'false';
+
+
             jq(document).ready(function () {
 
 
@@ -158,6 +161,67 @@
                 });
             }
 
+            //Return visit date is required if there is no transfer out
+            <!-- jq(document).ready(function () { 
+
+                jq(".transfer_out").change(function () {
+
+                    if(jq(this).find("input[type$='checkbox']:checked").val() =="90003") {
+                        returnVisitDateIsRequired = 'false';
+                    }
+                    else 
+                        returnVisitDateIsRequired = 'true';
+                });
+            }); -->
+
+
+            //Non POC mode: Return visit date is required if there is no transfer out
+            <!-- jq(document).ready(function () { 
+
+                jq(".transfer_out").change(function () {
+
+                    if(jq(this).find("input[type$='checkbox']:checked").val() =="90003") {
+                        
+                        jq(".returndate span").removeClass("required");
+                        //jq(".returndate span span error field-error").css("display", "none");
+                    }
+                    else 
+                        jq(".returndate span").addClass("required");
+                });
+            }); -->
+
+            //Check if any prescription is made, if so that return date will be mandatory
+            jq(document).ready(function () { 
+
+                jq(".prescription-poc").change(function () {
+                    var prescriptionMade =[];
+
+                    //if there is any value in the text box
+                    var ptext = jq(this).find("input[type$='text']").each(function() {
+                        if($(this).val()!="")
+                        prescriptionMade.push($(this).val());
+                    })
+                    
+                    //if there is any radio button checked
+                    jq(this).find("input[type$='radio']:checked").each(function() {
+                        if($(this).val()!=1066)
+                        prescriptionMade.push($(this).val());
+                    })
+
+                    //if any regimen is selected
+                    var regimen = jq(".regimen-given :selected").each(function() {
+                        if($(this).val()!="")
+                        prescriptionMade.push($(this).val());
+                    })
+
+                    if(prescriptionMade.length > 0 )
+                        prescription = 'true';
+                    else 
+                        prescription = 'false';
+                    
+                });
+            });
+
            jq(document).ready(function () {
                 $allRows_other = jq(this).find('.multi-drug-other');
                 $allRows_other.hide();
@@ -188,7 +252,7 @@
                 jq(contentAddId).toggle(false);
                 jq(':input:not(:button)', contentAddId).val([]);
                 jq('#' + correctedRemoveButtonId + '-addEntry-other').toggle(true);
-                jq('#' + correctedRemoveButtonId + '-removeEntry-other').toggle(true);
+                jq('#' + correctedRemoveButtonId + '-removeEntry-other').toggle(true);prescription-poc
 
                 return false;
                 });
@@ -337,6 +401,7 @@
                 });
 
             });
+
         <ifMode mode = "EDIT" >
             jq(document).ready(function () {
                 $allRows = jq(this).find('.multi-drug');
@@ -701,6 +766,7 @@
                     if (jq(this).find(':checkbox').prop('checked')) {
                         enable_fields("transfer_out_date");
                         enable_fields("transfer_out_location");
+                        
                     } else {
                         disable_fields("transfer_out_date");
                         disable_fields("transfer_out_location");
@@ -778,7 +844,6 @@
                         disable_fields("district-tb-no");
                     }
                 });
-
 
                 jq("#tb-status").change(function () {
                     if (jq(this).find("select").find(":selected").val() == "99421") {
@@ -870,7 +935,6 @@
                 /*disable fluconazole prescription*/
 
 
-
                 // enable number of fluconazole stop date if fluconazole start date is defined
                 jq("#fluconazole-start-date").change(function () {
                     if (jq(this).find("input[type=hidden]").val() != "") {
@@ -893,7 +957,6 @@
                         disable_fields("other-regimen");
                     }
                 });
-
 
 
                 /* enable art prescription */
@@ -1083,7 +1146,6 @@
                 });
 
 
-
                 jq("#enable-disable-other-poor-art-adherence-reason").change(function () {
                     if (jq(this).find(':checkbox').prop('checked')) {
                         jq("#other-poor-art-adherence-reason-enabled").find("input[type$='text']").attr("disabled", false);
@@ -1183,15 +1245,13 @@
                 setValue('other-meds-quantity.error','');
             </restrictByRole>
 
-
                 var encounterDate = new Date((getValue('encounterDate.value')));
                 var appointment = new Date((jq("#returndate").find('input[type=hidden]').val()));
-                var transferOutDate = new Date((getValue('transfer_out_date.value')));
+                var transferOutDate = new Date((getValue('transfer_out_date.value'))); 
+                var transferOut   = jq('.transfer_out').find("input[type$='checkbox']:checked").val();
+                var returnDate    = getValue('returndate.value');
+                var returnDatePoc = jq('.return-date-poc').find("input[type$='text']").val();
 
-                if(getValue('returndate.value')==""){
-                    jq().toastmessage('showErrorToast', "The return date is required");
-                    return false;
-                }
 
                 if(getValue('provider.value')==""){
                     jq().toastmessage('showErrorToast', "Attending clinician is required");
@@ -1204,8 +1264,14 @@
                     return false;
                 }
 
-                if(jq('.transfer_out').find("input[type$='checkbox']:checked").val() == 90003) {
+                //Return visit date is mandatory if any prescription is made
+                if(prescription=="true" &amp;&amp; returnDate=="") {
+                    jq().toastmessage('showErrorToast', "The return visit date is required");
+                    return false;
+                }
 
+                //In case of a transfer out
+                if(transferOut == 90003) {
                     if(getValue('transfer_out_date.value')==""){
                         jq().toastmessage('showErrorToast', "The transfer out date is required");
                         return false;
@@ -1217,6 +1283,11 @@
                     } 
                 }
 
+                if(transferOut !==90003 &amp;&amp; returnDatePoc =="") {
+                    jq().toastmessage('showErrorToast', "The return visit date is required");
+                    return false;
+                }
+                                                
                 if(getValue('transfer_out_date.value') !== "" &amp;&amp; encounterDate.getTime() !== transferOutDate.getTime()){
                     getField('transfer_out_date.error').html('The Transfer out date has to be exactly the same as the encounter date' +
                         formatDateForDisplay(encounterDate)).show();
@@ -1236,10 +1307,6 @@
                     jq().toastmessage('showErrorToast', "The return date must be before the transfer out date of "+(new Date(latestTransferOutEncounter.encounterDatetime)));
                         return false;
                 }
-
-
-
-
 
                 var viral_load_qualitative = getValue('viral-load-results-qualitative.value');
                 var date_viral_load_taken = getValue('date-viral-load-taken.value');
@@ -1267,7 +1334,6 @@
                     jq().toastmessage('showErrorToast', "Please enter the number of virus copies per ml. the minimum number of copies is 20");
                     return false;
                 }
-
 
                 /* if DSDM is not FBIM or FTR or Empty and patient is not stable should not save.*/
                 if (jq("#patient-categorization").find("select").find(":selected").val() !== "90003" &amp;&amp; (jq("#165143").find("select").find(":selected").val() !== "165138" &amp;&amp; jq("#165143").find("select").find(":selected").val() !== "165140" &amp;&amp; jq("#165143").find("select").find(":selected").val() !== "")) {
@@ -1484,9 +1550,7 @@
                 }
             });
 
-
         </ifMode>
-
 
         </includeIf>
 
@@ -1679,14 +1743,14 @@
                                                                             complexExpression="#set($transfer_out_date=($fn.latestObs('99165').valueDatetime)) #set($lost_to_follow_date=$fn.latestObs('99165').valueDatetime) #set($transfer_out=$fn.latestObs('90306').valueCoded.name) $transfer_out_date"/>
                                                                 </span>
                                                                 <includeIf velocityTest="$transfer_out=='YES'">
-                                                                    <label><span class="required">*</span>Return date</label>
+                                                                    <label>Return date</label>
                                                                     <obs id="returndate" conceptId="5096"
-                                                                         allowFutureDates="true" required="required"/>
+                                                                         allowFutureDates="true" class="return-date-poc"/>
                                                                 </includeIf>
                                                                 <includeIf velocityTest="$transfer_out!='YES'">
-                                                                    <label><span class="required">*</span>Return date</label>
+                                                                    <label>Return date</label>
                                                                     <obs id="returndate" conceptId="5096"
-                                                                         required="required" allowFutureDates="true"/>
+                                                                         allowFutureDates="true" class="return-date-poc"/>
                                                                 </includeIf>
                                                             </ifMode>
                                                             <ifMode mode="EDIT">
@@ -1695,14 +1759,14 @@
                                                                             complexExpression="#set($transfer_out_date=($fn.latestObs('99165').valueDatetime)) #set($lost_to_follow_date=$fn.latestObs('99165').valueDatetime) #set($transfer_out=$fn.latestObs('90306').valueCoded.name) $transfer_out_date"/>
                                                                 </span>
                                                                 <includeIf velocityTest="$transfer_out=='YES'">
-                                                                    <label><span class="required">*</span>Return date</label>
+                                                                    <label>Return date</label>
                                                                     <obs id="returndate" conceptId="5096"
-                                                                         allowFutureDates="true" required="required"/>
+                                                                         allowFutureDates="true" class="return-date-poc"/>
                                                                 </includeIf>
                                                                 <includeIf velocityTest="$transfer_out!='YES'">
-                                                                    <label><span class="required">*</span>Return date</label>
+                                                                    <label>Return date</label>
                                                                     <obs id="returndate" conceptId="5096"
-                                                                         required="required" allowFutureDates="true"/>
+                                                                         allowFutureDates="true" class="return-date-poc"/>
                                                                 </includeIf>
                                                             </ifMode>
                                                         </excludeIf>
@@ -1712,9 +1776,9 @@
                                                              style="checkbox"/>
                                                     </div>
                                                     <div class="col-md-3">
-                                                        <label><span class="required">*</span>Attending Clinician</label>
+                                                        <label>Attending Clinician</label>
                                                         <encounterProvider role="Provider" style="autocomplete" id="provider"/>
-                                                        <span style="display: none;">
+                                                        <span class="required">*</span><span style="display: none;">
                                                             <encounterLocation default="629d78e9-93e5-43b0-ad8a-48313fd99117"
                                                                                order="629d78e9-93e5-43b0-ad8a-48313fd99117"/>
                                                         </span>
@@ -2811,7 +2875,7 @@
                                                 <div class="row">
                                                     <div class="col-md-4" id="final-out-come">
                                                         <obs id="transfer_out" conceptId="90306" answerConceptId="90003"
-                                                             answerLabel="Transfer out" class="transfer_out"/>
+                                                             answerLabel="Transfer out" class="transfer_out" />
                                                     </div>
                                                     <div class="col-md-4" id="disabled">
                                                         <obs id="transfer_out_date" conceptId="99165" labelText="Date of Transfer" class="transfer_out_date"/>
@@ -2890,12 +2954,7 @@
                         <div class="card-header">
                             <ul class="nav nav-tabs card-header-tabs nav-fill">
                                 <li class="nav-item">
-                                    <a class="nav-link active" data-toggle="tab" href="#return-date">
-                                        Return Date
-                                    </a>
-                                </li>
-                                <li class="nav-item">
-                                    <a class="nav-link" data-toggle="tab" href="#patient-vitals">
+                                    <a class="nav-link active" data-toggle="tab" href="#patient-vitals">
                                         Triage Information
                                     </a>
                                 </li>
@@ -2917,30 +2976,7 @@
 
                             <div class="card-body">
                                 <div class="tab-content">
-                                <div class="tab-pane fade show active" id="return-date" >
-                                    <div class="row">
-                                        <div class="col-md-4">
-                                            <excludeIf velocityTest="$patient.person.dead ==true">
-                                                <lookup complexExpression="#set($transfer_out_date = '')"/>
-                                                <span id="transfer_out_date_id" class="hidden">
-                                                    <lookup
-                                                            complexExpression="#set($transfer_out_date=($fn.latestObs('99165').valueDatetime)) #set($lost_to_follow_date=$fn.latestObs('99165').valueDatetime) #set($transfer_out=$fn.latestObs('90306').valueCoded.name) $transfer_out_date"/>
-                                                </span>
-                                                <includeIf velocityTest="$transfer_out=='YES'">
-                                                    <label><span class="required">*</span>Return date</label>
-                                                        <obs id="returndate" conceptId="5096"
-                                                        required="required" allowFutureDates="true"/>
-                                                </includeIf>
-
-                                                <includeIf velocityTest="$transfer_out!='YES'">
-                                                    <label><span class="required">*</span>Return date</label>
-                                                        <obs id="returndate" conceptId="5096"                                                                required="required" allowFutureDates="true"/>
-                                                </includeIf>
-                                            </excludeIf>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="tab-pane fade show" id="patient-vitals" >
+                                <div class="tab-pane fade show active" id="patient-vitals" >
                                     <uiInclude provider="ugandaemr" fragment="vitals"/>
                                 </div>
                                 <div class="tab-pane fade" id="nav-family-planning" role="tabpanel" >
@@ -3617,13 +3653,13 @@
                                         <div class="card-header">
                                             ARV - regimens
                                         </div>
-                                        <div class="card-body">
+                                        <div class="card-body prescription-poc">
                                             <obsgroup groupingConceptId="165430">
                                                 <div class="row arv-regimen">
                                                     <div class="col-md-3">
                                                         <obs id="art-regimen" conceptId="90315" labelText="Regimen"
                                                              answerConceptIds="99015,99016,99005,99006,164979,99039,99040,164977,99041,99042,99007,99008,99044,99043,99282,99283,99046,99017,99018,99019,99045,99284,99285,99286,99884,99885,164978,99888,163017,99887,165797,165796,165795,165808,165807,165806,165805,165804,165803,165802,165801,165800,165799,165798,90002"
-                                                             answerLabels="d4T-3TC-NVP,d4T-3TC-EFV,AZT-3TC-NVP,AZT-3TC-EFV,AZT-3TC-DTG,TDF-3TC-NVP,TDF-3TC-EFV,TDF-3TC-DTG,TDF-FTC-NVP,TDF-FTC-EFV,ABC-ddI(250)-LPV/r,ABC-ddI(400)-LPV/r,TDF-3TC-LPV/r,TDF-FTC-LPV/r,ZDV-ddI(250)-LPV/r,ZDV-ddI(400)-LPV/r,AZT-3TC-LPV/r,ABC-ddI-LPV/r,ABC-ddI-NFV,ABC-ddI-SQV/r,ZDV-ddI-LPV/r,AZT-ABC-LPV/r,ABC-ddI-ATV/r,AZT-3TC-ATV/r,ABC-3TC-NVP,ABC-3TC-EFV,ABC-3TC-DTG,ABC-3TC-ATV/r,ABC-3TC-LPV/r,TDF-3TC-ATV/r,AZT/3TC/RAL,ABC/3TC/AZT,TDF/3TC/AZT,DRV/RTV/RAL/ABC/3TC,DRV/RTV/ETV/ABC/3TC,DRV/RTV/RAL/TDF/3TC,DRV/RTV/RAL/AZT/3TC,DRV/RTV/RAL,DRV/RTV/ETV/TDF/3TC,DRV/RTV/ETV/AZT/3TC,DRV/RTV/ETV,DRV/RTV/DTG/TDF/3TC,DRV/RTV/DTG/AZT/3TC,DRV/RTV/DTG,Other"/>
+                                                             answerLabels="d4T-3TC-NVP,d4T-3TC-EFV,AZT-3TC-NVP,AZT-3TC-EFV,AZT-3TC-DTG,TDF-3TC-NVP,TDF-3TC-EFV,TDF-3TC-DTG,TDF-FTC-NVP,TDF-FTC-EFV,ABC-ddI(250)-LPV/r,ABC-ddI(400)-LPV/r,TDF-3TC-LPV/r,TDF-FTC-LPV/r,ZDV-ddI(250)-LPV/r,ZDV-ddI(400)-LPV/r,AZT-3TC-LPV/r,ABC-ddI-LPV/r,ABC-ddI-NFV,ABC-ddI-SQV/r,ZDV-ddI-LPV/r,AZT-ABC-LPV/r,ABC-ddI-ATV/r,AZT-3TC-ATV/r,ABC-3TC-NVP,ABC-3TC-EFV,ABC-3TC-DTG,ABC-3TC-ATV/r,ABC-3TC-LPV/r,TDF-3TC-ATV/r,AZT/3TC/RAL,ABC/3TC/AZT,TDF/3TC/AZT,DRV/RTV/RAL/ABC/3TC,DRV/RTV/ETV/ABC/3TC,DRV/RTV/RAL/TDF/3TC,DRV/RTV/RAL/AZT/3TC,DRV/RTV/RAL,DRV/RTV/ETV/TDF/3TC,DRV/RTV/ETV/AZT/3TC,DRV/RTV/ETV,DRV/RTV/DTG/TDF/3TC,DRV/RTV/DTG/AZT/3TC,DRV/RTV/DTG,Other" class="regimen-given"/>
                                                     </div>
                                                     <div class="col-md-2">
                                                         <br/>
@@ -3688,7 +3724,7 @@
                                         <div class="card-header">
                                             TPT/B6
                                         </div>
-                                        <div class="card-body">
+                                        <div class="card-body prescription-poc">
                                             <obsgroup groupingConceptId="165305">
                                                 <div class="row">
                                                     <div class="col-md-3">
@@ -3738,9 +3774,9 @@
                             <div class="col-md-12">
                                 <div class="card">
                                     <div class="card-header">
-                                        CTX/DAPSONE (ANTI-BIOTICS)
+                                        CTX/DAPSONE (Anti-biotics)
                                     </div>
-                                    <div class="card-body">
+                                    <div class="card-body prescription-poc">
                                         <obsgroup groupingConceptId="165304">
                                             <div class="row">
                                                 <div class="col-md-3">
@@ -3773,9 +3809,9 @@
                                 <div class="col-md-12">
                                     <div class="card">
                                         <div class="card-header">
-                                            Fluconazole - (Anti-fungal)
+                                            Fluconazole (Anti-fungal)
                                         </div>
-                                        <div class="card-body">
+                                        <div class="card-body prescription-poc">
                                             <obsgroup groupingConceptId="165306">
                                                 <div class="row">
                                                     <div class="col-md-6">
@@ -3814,7 +3850,7 @@
                                         <div class="card-header">
                                             <label>Other Medications</label>
                                         </div>
-                                        <div class="card-body">
+                                        <div class="card-body prescription-poc">
                                             <div>
                                                 <repeat>
                                                     <template>
@@ -3968,7 +4004,27 @@
                                         </div>
                                     </div>
                                 </div>
-                                
+                                <div class="row">
+                                    <div class="col-md-4">
+                                        <excludeIf velocityTest="$patient.person.dead ==true">
+                                            <lookup complexExpression="#set($transfer_out_date = '')"/>
+                                            <span id="transfer_out_date_id" class="hidden">
+                                                <lookup
+                                                        complexExpression="#set($transfer_out_date=($fn.latestObs('99165').valueDatetime)) #set($lost_to_follow_date=$fn.latestObs('99165').valueDatetime) #set($transfer_out=$fn.latestObs('90306').valueCoded.name) $transfer_out_date"/>
+                                            </span>
+                                            <includeIf velocityTest="$transfer_out=='YES'">
+                                                <label>Return date</label>
+                                                    <obs id="returndate" conceptId="5096"
+                                                     allowFutureDates="true"/>
+                                            </includeIf>
+
+                                            <includeIf velocityTest="$transfer_out!='YES'">
+                                                <label>Return date</label>
+                                                    <obs id="returndate" conceptId="5096" allowFutureDates="true"/>
+                                            </includeIf>
+                                        </excludeIf>
+                                    </div>
+                                </div>
                                 <obsgroup groupingConceptId="99166">
                                     <div class="row">
                                         <div class="col-md-4" id="final-out-come">


### PR DESCRIPTION
https://app.asana.com/0/1133167201254915/1201769013495240/f

Changes Made
Made return date required in both POC and Retrospective
Made transfer date and transfer location required if transfer out is checked both in POC and Retrospective

NB: 
- Created a return date tab in POC and made it active by default so that its easily visible since its required before saving
