### PR TITLE
Fix failing retrospective of Ordering Viral Load

### DIFF
--- a/omod/src/main/webapp/resources/htmlforms/HMIS-HIV-003-HivCareArtCard-ClinicalAssessmentPage.xml
+++ b/omod/src/main/webapp/resources/htmlforms/HMIS-HIV-003-HivCareArtCard-ClinicalAssessmentPage.xml
@@ -1750,7 +1750,8 @@
                                                     </div>
                                                     <div class="col-md-3">
                                                         <label>Attending Clinician</label>
-                                                        <encounterProvider role="Provider" style="autocomplete" id="provider"/>
+                                                        <encounterProviderAndRole encounterRole="240b26f9-dd88-4172-823d-4a8bfeb7841f"
+                                                                                  required="required"  id="provider"/>
                                                         <span class="required">*</span><span style="display: none;">
                                                             <encounterLocation default="629d78e9-93e5-43b0-ad8a-48313fd99117"
                                                                                order="629d78e9-93e5-43b0-ad8a-48313fd99117"/>


### PR DESCRIPTION
https://app.asana.com/0/1133167201254913/1201855160110829
Ordering of viral load retrospectively failed due to encounter role provider missing. Only the Unknow encounter provider role is set at the time of ordering. 