### PR TITLE
remove search functionality from patient

### DIFF
--- a/api/src/main/resources/metadata/Role_Privilege.xml
+++ b/api/src/main/resources/metadata/Role_Privilege.xml
@@ -798,7 +798,6 @@
     <role_privilege  role="Reception"  privilege="App: datavisualiserui.downloaddata"/>
     <role_privilege  role="Reception"  privilege="Queue Patients"/>
     <role_privilege role="Reception" privilege="Manage Patient Queues"/>
-    <role_privilege role="Reception" privilege="Search Patient"/>
     <role_privilege role="Reception" privilege="View Reception Queuelist"/>
     <role_privilege role="Reception" privilege="View Reception Metrics"/>
     <role_privilege role="Reception" privilege="Add Patient Button"/>
@@ -924,6 +923,8 @@
     <role_privilege role="Organizational: Clinician" privilege="Manage patient attachments"/>
     <role_privilege role="Organizational: Clinician" privilege="Manage Patient Appointments Link"/>
     <role_privilege role="Organizational: Clinician" privilege="Stop Visit Button"/>
+    <role_privilege role="Organizational: Clinician" privilege="Search Patient"/>
+
 
 
 

--- a/tools/src/main/resources/frontendconfigs/configuration/frontend-config.json
+++ b/tools/src/main/resources/frontendconfigs/configuration/frontend-config.json
@@ -1174,14 +1174,10 @@
   "@openmrs/esm-patient-banner-app": {
     "extensionSlots": {
       "patient-actions-slot": {
+        "remove": [
+          "start-visit-button"
+        ],
         "configure": {
-          "start-visit-button": {
-            "Display conditions": {
-              "privileges": [
-                "Start Visit Button"
-              ]
-            }
-          },
           "stop-visit-button": {
             "Display conditions": {
               "privileges": [
@@ -1285,13 +1281,6 @@
           "start-visit-button"
         ],
         "configure": {
-          "start-visit-button": {
-            "Display conditions": {
-              "privileges": [
-                "Start Visit Button"
-              ]
-            }
-          },
           "stop-visit-button": {
             "Display conditions": {
               "privileges": [

--- a/tools/src/main/resources/frontendconfigs/configuration/frontend-config.json
+++ b/tools/src/main/resources/frontendconfigs/configuration/frontend-config.json
@@ -1281,6 +1281,9 @@
   "@openmrs/esm-patient-search-app": {
     "extensionSlots": {
       "patient-actions-slot": {
+        "remove": [
+          "start-visit-button"
+        ],
         "configure": {
           "start-visit-button": {
             "Display conditions": {


### PR DESCRIPTION
This PR removes redundant search functionality from reception user. It allows the utilisation of only the checkin search functionality.
